### PR TITLE
[03team] devcdper v06 teamproject 4차셋팅 - PSM

### DIFF
--- a/TESTdevcdper/src/main/java/com/devcdper/config/PlanConfig.java
+++ b/TESTdevcdper/src/main/java/com/devcdper/config/PlanConfig.java
@@ -1,0 +1,27 @@
+package com.devcdper.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.devcdper.interceptor.PlanInterceptor;
+
+@Configuration
+public class PlanConfig implements WebMvcConfigurer{
+	
+	private final PlanInterceptor planInterceptor;
+	
+	public PlanConfig(PlanInterceptor planInterceptor) {
+		this.planInterceptor = planInterceptor;
+	}
+	
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(planInterceptor)
+				.addPathPatterns("/**")
+				.excludePathPatterns("/AdminLTE3/**")
+				.excludePathPatterns("/js/**");
+		
+		WebMvcConfigurer.super.addInterceptors(registry);
+	}
+}

--- a/TESTdevcdper/src/main/java/com/devcdper/interceptor/PlanInterceptor.java
+++ b/TESTdevcdper/src/main/java/com/devcdper/interceptor/PlanInterceptor.java
@@ -1,0 +1,56 @@
+package com.devcdper.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Component
+public class PlanInterceptor implements HandlerInterceptor{
+private static final Logger log = LoggerFactory.getLogger(PlanInterceptor.class);
+	
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+			throws Exception {
+		HandlerMethod method = (HandlerMethod) handler;
+		log.info("CommonInterceptor=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-START");
+		log.info("Acess Info =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- START");
+		log.info("PORT			::::::::			{}", request.getLocalPort());
+		log.info("serverName			::::::::			{}", request.getServerName());
+		log.info("method			::::::::			{}", request.getMethod());
+		log.info("URI				::::::::			{}", request.getRequestURI());
+		log.info("CONTROLLER			::::::::			{}", method.getBean().getClass().getSimpleName());
+		log.info("Acess Info =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- END");
+		return HandlerInterceptor.super.preHandle(request, response, handler);
+	}
+	@Override
+	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+			ModelAndView modelAndView) throws Exception {
+		log.info("CommonInterceptor=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-END");
+		/* 슬러시 포함 경로 */
+		String uri = request.getRequestURI();
+		
+		/* 슬러시 제거한 순수 경로 */
+		String pathName = uri.substring(1);
+		
+		if(!"".equals(pathName)) {
+			
+			/* 경로와 일치하는 클래스명 검색을 위한 문자열조합 */
+			String className = "."+ pathName;
+			modelAndView.addObject("pathName", pathName);
+			modelAndView.addObject("className", className);
+		}
+		HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+	}
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+			throws Exception {
+		log.info("CommonInterceptor=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-AFTER");
+		HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+	}
+}

--- a/TESTdevcdper/src/main/java/com/devcdper/plan/controller/PlanController.java
+++ b/TESTdevcdper/src/main/java/com/devcdper/plan/controller/PlanController.java
@@ -1,9 +1,11 @@
 package com.devcdper.plan.controller;
 
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class PlanController {
@@ -14,16 +16,17 @@ public class PlanController {
 	public String totalPlan(Model model) {
 		model.addAttribute("title", "통합계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("radioCheck", "totalPlan");	//우측상단 경로이동 radioChecked
 		return "plan/totalPlan/totalPlan";
 	}
-	
 	/*------------------------------------------------통합계획등록 Start-----------------------------------------------------*/
 	@GetMapping("/addTotalPlan")
-	public String addTotalPlan(Model model) {
+	public String addTotalPlan(Model model
+							 , @RequestParam(name="planName", required = false)String planName) {
+		System.out.println(planName + " <<- planName");
+		model.addAttribute("planName", planName);
 		model.addAttribute("title", "통합계획등록");
 		model.addAttribute("function", "none");
-		return "plan/totalPlan/addTotalPlan";
+		return "fragments/plan/addTotalPlan";
 	}
 	@PostMapping("/addTotalPlan")
 	public String addTotalPlan() {
@@ -36,7 +39,7 @@ public class PlanController {
 	public String modifyTotalPlan(Model model) {
 		model.addAttribute("title", "통합계획수정");
 		model.addAttribute("function", "none");
-		return"plan/totalPlan/modifyTotalPlan";
+		return"fragments/plan/modifyTotalPlan";
 	}
 	
 	@PostMapping("/modifyTotalPlan")
@@ -63,7 +66,6 @@ public class PlanController {
 	public String mainPlan(Model model) {
 		model.addAttribute("title", "나의 계획 한눈에 보기");
 		model.addAttribute("function", "plan");
-		model.addAttribute("radioCheck", "plan");
 		return "plan/mainPlan";
 	}
 	@GetMapping("/mainCdp")
@@ -116,6 +118,23 @@ public class PlanController {
 	model.addAttribute("function", "plan");
 	return "plan/plan/planEducationalHistory";
 	}
+	
+	/*
+	@ResponseBody
+	@PostMapping("/planEducationalHistory")
+	public String planEducationalHistory(@RequestParam(name="firstSelect", required = false)String firstSelect, RedirectAttributes reAttr) {
+		 Map<String,Object> map = new HashMap<String,Object>();
+		
+		
+		 if(firstSelect != null && firstSelect.equals("계획")){
+		 System.out.println("계획 조건문통과"); map.put("planEducationalHistory",
+		 "planEducationalHistory"); }else if(firstSelect != null &&
+		 firstSelect.equals("상세계획")){ System.out.println("상세계획 조건문통과"); }else
+		 if(firstSelect != null && firstSelect.equals("실천계획")){
+		 System.out.println("실천계획 조건문통과"); };
+		 reAttr.addAttribute("planMap", map); 
+		return "redirect:/planEducationalHistory";
+	}*/
 	/*------------------------------------------------학력 계획 관리 End-----------------------------------------------------*/
 	/*------------------------------------------------프로젝트 계획 관리 Start-----------------------------------------------------*/
 	@GetMapping("/planProject")

--- a/TESTdevcdper/src/main/resources/static/AdminLTE3/dist/js/plan/planSelect.js
+++ b/TESTdevcdper/src/main/resources/static/AdminLTE3/dist/js/plan/planSelect.js
@@ -1,0 +1,118 @@
+var firstSelect = $('#planSelectMenu').children().first();
+var secondSelect = $('#planSelectMenu').children().last();
+
+/* 선택한 상위메뉴에 따른 하위메뉴 설정 */
+firstSelect.change(function(){
+	var firstVal = firstSelect.val();
+	if(!firstVal == undefined || firstVal == '계획'){
+		secondSelect.html('');
+		secondSelect.prop('disabled',false);
+		secondSelect.append("<option>하위 메뉴 선택</option>"
+						   +"<option>학력 계획</option>"
+						   +"<option>프로젝트 계획</option>"
+						   +"<option>자격증 계획</option>"
+						   +"<option>공인어학 계획</option>"
+						   +"<option>기술스택 계획</option>"
+						   +"<option>직종전문교육과정 계획</option>"
+						   +"<option>인턴십 계획</option>"
+						   +"<option>공모전 계획</option>"
+						   +"<option>경력 계획</option>");
+	}else if(!firstVal == undefined || firstVal == '상세계획'){
+		secondSelect.html('');
+		secondSelect.prop('disabled',false);
+		secondSelect.append("<option>하위 메뉴 선택</option>"
+						   +"<option>학력 상세 계획</option>"
+						   +"<option>프로젝트 상세 계획</option>"
+						   +"<option>자격증 상세 계획</option>"
+						   +"<option>공인어학 상세 계획</option>"
+						   +"<option>기술스택 상세 계획</option>"
+						   +"<option>직종전문교육과정 상세 계획</option>"
+						   +"<option>인턴십 상세 계획</option>"
+						   +"<option>공모전 상세 계획</option>"
+						   +"<option>경력 상세 계획</option>");
+	}else if(!firstVal == undefined || firstVal == '실천계획'){
+		secondSelect.html('');
+		secondSelect.prop('disabled',false);
+		secondSelect.append("<option>하위 메뉴 선택</option>"
+						   +"<option>학력 실천 계획</option>"
+						   +"<option>프로젝트 실천 계획</option>"
+						   +"<option>자격증 실천 계획</option>"
+						   +"<option>공인어학 실천 계획</option>"
+						   +"<option>기술스택 실천 계획</option>"
+						   +"<option>직종전문교육과정 실천 계획</option>"
+						   +"<option>인턴십 실천 계획</option>"
+						   +"<option>공모전 실천 계획</option>"
+						   +"<option>경력 실천 계획</option>");
+	}else if(!firstVal == undefined || firstVal == '통합계획'){
+		window.location.assign("/totalPlan");
+	}else {
+		secondSelect.html('');
+		secondSelect.prop('disabled',true);
+		secondSelect.append("<option>하위메뉴</option>");
+	};
+});
+
+/* select 하위메뉴 경로설정 시작 */
+secondSelect.change(function(){
+	secondSelect.find('option').each(function(){
+		if($(this).is(':selected')){
+			var selectOption = $(this).text();
+			if(selectOption == '학력 계획' && selectOption != null){
+				window.location.assign("/planEducationalHistory");
+			}else if(selectOption == '프로젝트 계획' && selectOption != null){
+				window.location.assign("/planProject");
+			}else if(selectOption == '자격증 계획' && selectOption != null){
+				window.location.assign("/planCertificate");
+			}else if(selectOption == '공인어학 계획' && selectOption != null){
+				window.location.assign("/planCertifiedLanguage");
+			}else if(selectOption == '기술스택 계획' && selectOption != null){
+				window.location.assign("/planTechnologyStack");
+			}else if(selectOption == '직종전문교육과정 계획' && selectOption != null){
+				window.location.assign("/planJobTraining");
+			}else if(selectOption == '인턴십 계획' && selectOption != null){
+				window.location.assign("/planInternship");
+			}else if(selectOption == '공모전 계획' && selectOption != null){
+				window.location.assign("/planContest");
+			}else if(selectOption == '경력 계획' && selectOption != null){
+				window.location.assign("/planCareer");
+			}else if(selectOption == '학력 상세 계획' && selectOption != null){
+				window.location.assign("/planEducationalHistoryDetail");
+			}else if(selectOption == '프로젝트 상세 계획' && selectOption != null){
+				window.location.assign("/planProjectDetail");
+			}else if(selectOption == '자격증 상세 계획' && selectOption != null){
+				window.location.assign("/planCertificateDetail");
+			}else if(selectOption == '공인어학 상세 계획' && selectOption != null){
+				window.location.assign("/planCertifiedLanguageDetail");
+			}else if(selectOption == '기술스택 상세 계획' && selectOption != null){
+				window.location.assign("/planTechnologyStackDetail");
+			}else if(selectOption == '직종전문교육과정 상세 계획' && selectOption != null){
+				window.location.assign("/planJobTrainingDetail");
+			}else if(selectOption == '인턴십 상세 계획' && selectOption != null){
+				window.location.assign("/planInternshipDetail");
+			}else if(selectOption == '공모전 상세 계획' && selectOption != null){
+				window.location.assign("/planContestDetail");
+			}else if(selectOption == '경력 상세 계획' && selectOption != null){
+				window.location.assign("/planCareerDetail");
+			}else if(selectOption == '학력 실천 계획' && selectOption != null){
+				window.location.assign("/actionEducationalHistory");
+			}else if(selectOption == '프로젝트 실천 계획' && selectOption != null){
+				window.location.assign("/actionProject");
+			}else if(selectOption == '자격증 실천 계획' && selectOption != null){
+				window.location.assign("/actionCertificate");
+			}else if(selectOption == '공인어학 실천 계획' && selectOption != null){
+				window.location.assign("/actionCertifiedLanguage");
+			}else if(selectOption == '기술스택 실천 계획' && selectOption != null){
+				window.location.assign("/actionTechnologyStack");
+			}else if(selectOption == '직종전문교육과정 실천 계획' && selectOption != null){
+				window.location.assign("/actionJobTraining");
+			}else if(selectOption == '인턴십 실천 계획' && selectOption != null){
+				window.location.assign("/actionInternship");
+			}else if(selectOption == '공모전 실천 계획' && selectOption != null){
+				window.location.assign("/actionContest");
+			}else if(selectOption == '경력 실천 계획' && selectOption != null){
+				window.location.assign("/actionCareer");
+			};
+		};
+	});
+});
+/* select 하위메뉴 경로설정 종료 */

--- a/TESTdevcdper/src/main/resources/templates/fragments/left.html
+++ b/TESTdevcdper/src/main/resources/templates/fragments/left.html
@@ -112,291 +112,398 @@
 				</li>
 				
 				<!-- 최종 스펙 관리 -->
-				<li class="nav-item" th:if="${function == null}"><a
-					th:href="@{/lastSpac}" class="nav-link"> <i
-						class="nav-icon far fa-file-alt"></i>
-						<p>최종 스펙 관리</p>
-				</a></li>
+				<li class="nav-item lastSpac" th:if="${function == null}">
+					<a th:href="@{/lastSpac}" class="nav-link">
+						<i class="nav-icon far fa-file-alt"></i>
+						<p>
+							최종 스펙 관리
+						</p>
+					</a>
+				</li>
 				<!-- 경력 관리서 관리 -->
-				<li class="nav-item" th:if="${function == null}"><a
-					th:href="@{/careerManagement}" class="nav-link"> <i
-						class="nav-icon far fa-file-alt"></i>
-						<p>경력 관리서 관리</p>
-				</a></li>
+				<li class="nav-item careerManagement" th:if="${function == null}">
+					<a th:href="@{/careerManagement}" class="nav-link">
+						<i class="nav-icon far fa-file-alt"></i>
+						<p>
+							경력 관리서 관리
+						</p>
+					</a>
+				</li>
 				<!-- 전체 계획 관리 Start -->
 				<li class="nav-item has-treeview" th:if="${function == null}">
-					<a href="#" class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
+					<a href="#" class="nav-link">
+						<i class="nav-icon fas fa-tasks "></i>
 						<p>
-							계획 관리 <i class="right fas fa-angle-left"></i>
+							계획 관리
+							<i class="right fas fa-angle-left"></i>
 						</p>
-				</a>
+					</a>
 					<ul class="nav nav-treeview" style="background-color: #2E2E2E;">
-						<li class="nav-item"><a th:href="@{/totalPlan}"
-							class="nav-link"> <!--  <i class="nav-icon far fa-file-alt"></i> -->
+						<li class="nav-item">
+							<a th:href="@{/totalPlan}" class="nav-link">
+								<!--  <i class="nav-icon far fa-file-alt"></i> -->
 								<i class="nav-icon fas fa-tasks "></i>
-								<p>
-									통합 계획 관리(박승민) <span style="font-size: 10px;"
-										class="badge badge-primary">#</span>
+								<p>통합 계획 관리(박승민)
+									<span style="font-size: 10px;" class="badge badge-primary">#</span>
 								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/mainPlan}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>계획 관리(박승민)</p> <span style="font-size: 10px;"
-								class="badge badge-primary">#</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/detailPlan}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>상세 계획 관리(류준혁)</p> <span style="font-size: 10px;"
-								class="badge badge-primary">#</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionPlan}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>실천 계획 관리(김도연)</p> <span style="font-size: 10px;"
-								class="badge badge-primary">#</span>
-						</a></li>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a th:href="@{/mainPlan}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>계획 관리(박승민)</p>
+								<span style="font-size: 10px;" class="badge badge-primary">#</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a th:href="@{/planEducationalHistoryDetail}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>상세 계획 관리(류준혁)</p>
+								<span style="font-size: 10px;" class="badge badge-primary">#</span>
+							</a>
+						</li>
+						<li class="nav-item">
+							<a th:href="@{/actionPlan}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>실천 계획 관리(김도연)</p>
+								<span style="font-size: 10px;" class="badge badge-primary">#</span>
+							</a>
+						</li>
 					</ul>
 				</li>
 				<!--전체 계획 관리 종료-->
 
 
 				<!-- 계획 전용 left Start -->
-				<li class="nav-item" th:if="${function == 'plan'}"><a
-					th:href="@{/totalPlan}" class="nav-link"> <!--  <i class="nav-icon far fa-file-alt"></i> -->
+				<li class="nav-item" th:if="${function == 'plan'}">
+					<a th:href="@{/totalPlan}" class="nav-link">
+						<!--  <i class="nav-icon far fa-file-alt"></i> -->
 						<i class="nav-icon fas fa-tasks "></i>
-						<p>
-							통합 계획 관리(박승민) <span style="font-size: 10px;"
-								class="badge badge-primary">#</span>
+						<p>통합 계획 관리(박승민)
+							<span style="font-size: 10px;" class="badge badge-primary">!</span>
 						</p>
-				</a></li>
-				<li class="nav-item" th:if="${function == 'plan'}"><a
-					th:href="@{/mainPlan}" class="nav-link"> <i
-						class="nav-icon fas fa-tasks "></i>
-						<p>계획 관리(박승민)</p> <span style="font-size: 10px;"
-						class="badge badge-primary">#</span> <i
-						class="right fas fa-angle-left"></i>
-				</a> <!-- 계획관리 하위메뉴 시작 -->
-					<ul class="nav nav-treeview" style="background-color: #151515;">
-						<li class="nav-item"><a th:href="@{/mainPlan}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									나의 계획 한눈에보기 <span style="font-size: 10px;"
-										class="badge badge-primary">#</span>
-								</p>
-
-						</a>
-						<li class="nav-item"><a th:href="@{/planEducationalHistory}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									학력 계획 <span style="font-size: 10px;" class="badge badge-danger">!</span>
-								</p>
-
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planProject}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									프로젝트 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planCertificate}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									자격증 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planCertifiedLanguage}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									공인어학 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planTechnologyStack}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									기술스택 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planJobTraining}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									직종전문교육과정 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planInternship}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									인턴십 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planContest}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									공모전 계획 <span style="font-size: 10px;"
-										class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planCareer}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>
-									경력 계획 <span style="font-size: 10px;" class="badge badge-danger">!</span>
-								</p>
-						</a></li>
-					</ul></li>
-				<!-- 승민 계획 관리 하위메뉴 END -->
-				<li class="nav-item" th:if="${function == 'plan'}"><a
-					th:href="@{/detailPlan}" class="nav-link"> <i
-						class="nav-icon fas fa-tasks "></i>
-						<p>상세 계획 관리(류준혁)</p> <span style="font-size: 10px;"
-						class="badge badge-primary">#</span> <i
-						class="right fas fa-angle-left"></i>
-				</a> <!-- 상세계획관리 하위메뉴 시작  -->
-					<ul class="nav nav-treeview" style="background-color: #151515;">
-						<li class="nav-item"><a th:href="@{/detailPlan}"
-							class="nav-link">
-								<!--href="plan/detailPlan.html" 대신 th로  --> <i
-								class="nav-icon far fa-file-alt"></i>
-								<p>상세 계획 한눈에 보여주기</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-
-						<li class="nav-item"><a
-							th:href="@{/planEducationalHistoryDetail}" class="nav-link">
-								<i class="nav-icon far fa-file-alt"></i>
-								<p>학력 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planProjectDetail}"
-							class="nav-link"> <i class="nav-icon far fa-file-alt"></i>
-								<p>프로젝트 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planCertificateDetail}"
-							class="nav-link"> <i class="nav-icon far fa-file-alt"></i>
-								<p>자격증 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a
-							th:href="@{/planCertifiedLanguageDetail}" class="nav-link"> <i
-								class="nav-icon far fa-file-alt"></i>
-								<p>공인어학 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a
-							th:href="@{/planTechnologyStackDetail}" class="nav-link"> <i
-								class="nav-icon far fa-file-alt"></i>
-								<p>기술스택 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planJobTrainingDetail}"
-							class="nav-link"> <i class="nav-icon far fa-file-alt"></i>
-								<p>직종전문교육과정 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planInternshipDetail}"
-							class="nav-link"> <i class="nav-icon far fa-file-alt"></i>
-								<p>인턴십 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planContestDetail}"
-							class="nav-link"> <i class="nav-icon far fa-file-alt"></i>
-								<p>공모전 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/planCareerDetail}"
-							class="nav-link"> <i class="nav-icon far fa-file-alt"></i>
-								<p>경력 상세 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-					</ul></li>
-				<!-- 상세계획관리 하위메뉴 종료  -->
+					</a>
 				</li>
-				<li class="nav-item" th:if="${function == 'plan'}"><a
-					th:href="@{/actionPlan}" class="nav-link"> <i
-						class="nav-icon fas fa-tasks "></i>
-						<p>실천 계획 관리(김도연)</p> <span style="font-size: 10px;"
-						class="badge badge-primary">#</span> <i
-						class="right fas fa-angle-left"></i>
-				</a> <!-- 실천계획관리 하위메뉴 시작 -->
+				<li class="nav-item" th:if="${function == 'plan'}">
+					<a th:href="@{/mainPlan}" class="nav-link">
+						<i class="nav-icon fas fa-tasks "></i>
+						<p>계획 관리(박승민)</p>
+						<span style="font-size: 10px;" class="badge badge-primary">!</span>
+						<i class="right fas fa-angle-left"></i>
+					</a>
+					<!-- 계획관리 하위메뉴 시작 -->
 					<ul class="nav nav-treeview" style="background-color: #151515;">
-						<li class="nav-item"><a
-							th:href="@{/actionEducationalHistory}" class="nav-link"> <!--  <i class="nav-icon far fa-file-alt"></i> -->
+						<li class="nav-item mainPlan">
+							<a th:href="@{/mainPlan}" class="nav-link">
 								<i class="nav-icon fas fa-tasks "></i>
-								<p>학력 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionProject}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>프로젝트 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionCertificate}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>자격증 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionCertifiedLanguage}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>공인어학 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionTechnologyStack}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>기술스택 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionJobTraining}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>직종전문교육과정 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionInternship}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>인턴십 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionContest}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>공모전 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/actionCareer}"
-							class="nav-link"> <i class="nav-icon fas fa-tasks "></i>
-								<p>경력 실천 계획</p> <span style="font-size: 10px;"
-								class="badge badge-danger">!</span>
-						</a></li>
-					</ul> <!-- 실천 계획 관리 하위메뉴 종료 --></li>
+								<p>1.나의 계획 한눈에보기
+									<span style="font-size: 10px;" class="badge badge-primary">!</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planEducationalHistory">
+							<a th:href="@{/planEducationalHistory}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>2.학력 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+
+						<li class="nav-item planProject">
+							<a th:href="@{/planProject}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>3.프로젝트 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planCertificate">
+							<a th:href="@{/planCertificate}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>4.자격증 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planCertifiedLanguage">
+							<a th:href="@{/planCertifiedLanguage}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>5.공인어학 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planTechnologyStack">
+							<a th:href="@{/planTechnologyStack}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>6.기술스택 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planJobTraining">
+							<a th:href="@{/planJobTraining}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>7.직종전문교육과정 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planInternship">
+							<a th:href="@{/planInternship}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>8.인턴십 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planContest">
+							<a th:href="@{/planContest}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>9.공모전 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item planCareer">
+							<a th:href="@{/planCareer}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>10.경력 계획
+									<span style="font-size: 10px;" class="badge badge-danger">#</span>
+								</p>
+							</a>
+						</li>
+					</ul>
+					<!-- 승민 계획 관리 하위메뉴 END -->
+				</li>
+				<!-- 승민 계획 관리 END -->
+				
+				<!-- 준혁 상세 계획 관리 STRAT -->
+				<li class="nav-item" th:if="${function == 'plan'}">
+					<a th:href="@{/detailPlan}" class="nav-link">
+						<i class="nav-icon fas fa-tasks "></i>
+						<p>상세 계획 관리(류준혁)</p>
+						<span style="font-size: 10px;" class="badge badge-primary">#</span>
+						<i class="right fas fa-angle-left"></i>
+					</a>
+					<!-- 준혁 상세 계획 관리 하위메뉴 STRAT  -->
+					<ul class="nav nav-treeview" style="background-color: #151515;">
+						<li class="nav-item detailPlan">
+							<a th:href="@{/detailPlan}" class="nav-link">
+								<!--href="plan/detailPlan.html" 대신 th로  -->
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>1.상세 계획 한눈에 보여주기
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planEducationalHistoryDetail">
+							<a th:href="@{/planEducationalHistoryDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>2.학력 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planProjectDetail">
+							<a th:href="@{/planProjectDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>3.프로젝트 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planCertificateDetail">
+							<a th:href="@{/planCertificateDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>4.자격증 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planCertifiedLanguageDetail">
+							<a th:href="@{/planCertifiedLanguageDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>5.공인어학 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planTechnologyStackDetail">
+							<a th:href="@{/planTechnologyStackDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>6.기술스택 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planJobTrainingDetail">
+							<a th:href="@{/planJobTrainingDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>7.직종전문교육과정 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planInternshipDetail">
+							<a th:href="@{/planInternshipDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>8.인턴십 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planContestDetail">
+							<a th:href="@{/planContestDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>9.공모전 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item planCareerDetail">
+							<a th:href="@{/planCareerDetail}" class="nav-link">
+								<i class="nav-icon far fa-file-alt"></i>
+								<p>10.경력 상세 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+					</ul>
+					<!-- 준혁 상세 계획 관리 하위메뉴 END -->
+				</li>
+				<!-- 준혁 상세 계획 관리 END -->
+				
+				<!-- 도연 실천 계획 관리 START -->
+				<li class="nav-item" th:if="${function == 'plan'}">
+					<a th:href="@{/actionPlan}" class="nav-link">
+						<i class="nav-icon fas fa-tasks "></i>
+						<p>실천 계획 관리(김도연)</p>
+						<span style="font-size: 10px;" class="badge badge-primary">#</span>
+						<i class="right fas fa-angle-left"></i>
+					</a>
+					<!-- 도연 실천 계획 관리 하위메뉴 START -->
+					<ul class="nav nav-treeview" style="background-color: #151515;">
+						<li class="nav-item actionPlan">
+							<a th:href="@{/actionPlan}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>1.나의 실천 계획 한눈에보기
+									<span style="font-size: 10px;" class="badge badge-primary">!</span>
+								</p>
+							</a>
+						</li>
+						<li class="nav-item actionEducationalHistory">
+							<a th:href="@{/actionEducationalHistory}" class="nav-link">
+								<!--  <i class="nav-icon far fa-file-alt"></i> -->
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>2.학력 실천 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionProject">
+							<a th:href="@{/actionProject}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>3.프로젝트 실천 계획
+								</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionCertificate">
+							<a th:href="@{/actionCertificate}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>4.자격증 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionCertifiedLanguage">
+							<a th:href="@{/actionCertifiedLanguage}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>5.공인어학 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionTechnologyStack">
+							<a th:href="@{/actionTechnologyStack}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>6.기술스택 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionJobTraining">
+							<a th:href="@{/actionJobTraining}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>7.직종전문교육과정 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionInternship">
+							<a th:href="@{/actionInternship}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>8.인턴십 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionContest">
+							<a th:href="@{/actionContest}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>9.공모전 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+						<li class="nav-item actionCareer">
+							<a th:href="@{/actionCareer}" class="nav-link">
+								<i class="nav-icon fas fa-tasks "></i>
+								<p>10.경력 실천 계획</p>
+								<span style="font-size: 10px;" class="badge badge-danger">#</span>
+							</a>
+						</li>
+					</ul>
+					<!-- 도연 실천 계획 관리 하위메뉴 END -->
+				</li>
+				<!-- 도연 실천 계획 관리 END -->
 				<!--계획 전용 left 관리 종료-->
 
 				<!-- 코칭 관리 -->
 				<li class="nav-item has-treeview" th:if="${function == null}">
-					<a th:href="@{/mainCoaching}" class="nav-link"> <i
-						class="nav-icon fab fa-dev"></i>
+					<a th:href="@{/mainCoaching}" class="nav-link">
+						<i class="nav-icon fab fa-dev"></i>
 						<p>
-							!코칭 관리 <i class="right fas fa-angle-left"></i>
+							코칭 !
+							<i class="right fas fa-angle-left"></i>
 						</p>
-				</a>
-					<ul class="nav nav-treeview">
-						<li class="nav-item"><a th:href="@{/mentoring}"
-							class="nav-link"> <i class="nav-icon fab fa-dev"></i>
-								<p>!멘토링 관리</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/consulting}"
-							class="nav-link"> <i class="nav-icon fab fa-dev"></i>
-								<p>!컨설팅 관리</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/coachAdmin}"
-							class="nav-link"> <i class="nav-icon fab fa-dev"></i>
-								<p>#코치 관리</p>
-						</a></li>
-						<li class="nav-item"><a th:href="@{/coachingReview}"
-							class="nav-link"> <i class="nav-icon fab fa-dev"></i>
-								<p>#리뷰 관리</p>
-						</a></li>
+					</a>
+					<ul class="nav nav-treeview" style="background-color: #151515;">
+						<li class="nav-item mentoring">
+							<a th:href="@{/mentoring}" class="nav-link">
+								<i class="nav-icon fab fa-dev"></i>
+								<p>1.멘토링 !</p>
+							</a>
+						</li>
+						<li class="nav-item consulting">
+							<a th:href="@{/consulting}" class="nav-link">
+								<i class="nav-icon fab fa-dev"></i>
+								<p>2.컨설팅 !</p>
+							</a>
+						</li>
+						<li class="nav-item myCoachingClient">
+							<a th:href="@{/myCoachingClient}" class="nav-link">
+								<i class="nav-icon fab fa-dev"></i>
+								<p>3.나의 코칭(일반) !</p>
+							</a>
+						</li>
+						<li class="nav-item myCoachingCoach">
+							<a th:href="@{/myCoachingCoach}" class="nav-link">
+								<i class="nav-icon fab fa-dev"></i>
+								<p>4.나의 코칭(코치) !</p>
+							</a>
+						</li>
+						<li class="nav-item coachingAdminPage">
+							<a th:href="@{/coachingAdminPage}" class="nav-link">
+								<i class="nav-icon fab fa-dev"></i>
+								<p>5.코칭 관리자 페이지 !</p>
+							</a>
+						</li>
 					</ul>
 				</li>
 

--- a/TESTdevcdper/src/main/resources/templates/fragments/plan/addTotalPlan.html
+++ b/TESTdevcdper/src/main/resources/templates/fragments/plan/addTotalPlan.html
@@ -1,48 +1,34 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
 	  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-	  layout:decorator="layout/default">
+	  layout:decorate="@{layout/default}">
 <th:block layout:fragment="pageTitle">
 	<title th:text="${title}">Insert title here</title>
 	<div class="col-sm-6">
-		<h1 class="m-0">통합계획수정</h1>
+		<h1 class="m-0" th:text="${planName}+'등록'">등록</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-6">
-		<ol class="breadcrumb float-sm-right">
-			<li class="breadcrumb-item"><a th:href="@{/totalPlan}">통합계획</a></li>
-			<li class="breadcrumb-item"><a th:href="@{/mainPlan}">계획</a></li>
-			<li class="breadcrumb-item"><a th:href="@{/detailPlan}">상세계획</a></li>
-			<li class="breadcrumb-item"><a th:href="@{/actionPlan}">실천계획</a></li>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
 	<section class="content">
 		<!-- Default box -->
-		<div class="card">
-			<div class="card-header">
-				<h3 class="card-title">
-					통합계획수정
-				</h3>
-    		</div>
-			
-			<!-- card-body -->
-			<!-- Content Wrapper. Contains page content -->
-			<div class="card-body" style="margin-left: unset; background-color: #F2F2F2;">
-				<form th:action="@{/modifyTotalPlan}" method="POST">
+				<form th:action="@{/addTotalPlan}" method="POST">
 					<div class="container-fluid" th:align="center">
 						<div class="col-md-6" style="text-align: left;">
+						
+						
 							<div class="card card-primary">
 								<div class="card-header">
-									<h3 class="card-title">통합계획정보수정</h3>
+									<h3 class="card-title"th:text="${planName}+'정보입력'">정보입력</h3>
 								</div>
 								<div class="card-body">
 									<div class="form-group">
-										<label for="totlaPlanName">통합계획 명</label>
+										<label for="totlaPlanTitle" th:text="${planName}+'제목'">제목</label>
 										<input type="text" id="totlaPlanName" class="form-control">
 									</div>
 									<div class="form-group">
-										<label for="totlaPlanContent">통합계획 내용</label>
+										<label for="totlaPlanContents"th:text="${planName}+'내용'">내용</label>
 										<textarea id="totlaPlanContent" class="form-control" rows="4"></textarea>
 									</div>
 									<div class="form-group">
@@ -54,12 +40,11 @@
 										<input type="date" id="totlaPlanEndDate" class="form-control">
 									</div>
 									<div class="form-group">
-										<label for="totlaPlanStatus">상태</label>
+										<label for="totlaPlanDivision">시작 유형</label>
 										<select id="totlaPlanStatus" class="form-control custom-select">
-											<option selected disabled>상태 선택</option>
-											<option>진행중</option>
-											<option>중단됨</option>
-											<option>완료</option>
+											<option selected disabled>유형선택</option>
+											<option>혼자하기</option>
+											<option>도움받기</option>
 										</select>
 									</div>
 									<div hidden>
@@ -70,20 +55,18 @@
 								<!-- /.card-body -->
 							</div>
 							<!-- /.card -->
-						</div>
-					</div>
-					<div class="row">
-						<div class="col-12">
-							<a th:href="@{/totalPlan}" class="btn btn-danger">취소</a>
-							<button type="submit" class="btn btn-primary float-right">수정완료</button>
+							<div class="row">
+								<div class="col-12">
+									<a th:href="@{/totalPlan}" class="btn btn-danger">취소</a>
+									<button type="submit" class="btn btn-primary float-right" th:text="${planName}+'등록'">등록</button>
+								</div>
+							</div>
 						</div>
 					</div>
 				</form>
 				<!-- /.content -->
-			</div>
 			<!-- /.content-wrapper -->
 			<!-- /.card-body -->
-		</div>
 		<!-- /.card -->
 	</section>
 </th:block>

--- a/TESTdevcdper/src/main/resources/templates/fragments/plan/modifyTotalPlan.html
+++ b/TESTdevcdper/src/main/resources/templates/fragments/plan/modifyTotalPlan.html
@@ -1,32 +1,32 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
 	  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-	  layout:decorate="@{layout/default}">
+	  layout:decorator="layout/default">
 <th:block layout:fragment="pageTitle">
 	<title th:text="${title}">Insert title here</title>
 	<div class="col-sm-6">
-		<h1 class="m-0">통합계획등록</h1>
-	</div><!-- /.col -->
-	<div class="col-sm-6">
-		<ol class="breadcrumb float-sm-right">
-			<li class="breadcrumb-item"><a th:href="@{/totalPlan}">통합계획</a></li>
-			<li class="breadcrumb-item"><a th:href="@{/mainPlan}">계획</a></li>
-			<li class="breadcrumb-item"><a th:href="@{/detailPlan}">상세계획</a></li>
-			<li class="breadcrumb-item"><a th:href="@{/actionPlan}">실천계획</a></li>
-		</ol>
+		<h1 class="m-0">통합계획수정</h1>
 	</div><!-- /.col -->
 </th:block>
 <th:block layout:fragment="container">
 	<section class="content">
 		<!-- Default box -->
-				<form th:action="@{/addTotalPlan}" method="POST">
+		<div class="card">
+			<div class="card-header">
+				<h3 class="card-title">
+					통합계획수정
+				</h3>
+    		</div>
+			
+			<!-- card-body -->
+			<!-- Content Wrapper. Contains page content -->
+			<div class="card-body" style="margin-left: unset; background-color: #F2F2F2;">
+				<form th:action="@{/modifyTotalPlan}" method="POST">
 					<div class="container-fluid" th:align="center">
 						<div class="col-md-6" style="text-align: left;">
-						
-						
 							<div class="card card-primary">
 								<div class="card-header">
-									<h3 class="card-title">통합계획정보입력</h3>
+									<h3 class="card-title">통합계획정보수정</h3>
 								</div>
 								<div class="card-body">
 									<div class="form-group">
@@ -62,18 +62,20 @@
 								<!-- /.card-body -->
 							</div>
 							<!-- /.card -->
-							<div class="row">
-								<div class="col-12">
-									<a th:href="@{/totalPlan}" class="btn btn-danger">취소</a>
-									<button type="submit" class="btn btn-primary float-right">통합계획 생성하기</button>
-								</div>
-							</div>
+						</div>
+					</div>
+					<div class="row">
+						<div class="col-12">
+							<a th:href="@{/totalPlan}" class="btn btn-danger">취소</a>
+							<button type="submit" class="btn btn-primary float-right">수정완료</button>
 						</div>
 					</div>
 				</form>
 				<!-- /.content -->
+			</div>
 			<!-- /.content-wrapper -->
 			<!-- /.card-body -->
+		</div>
 		<!-- /.card -->
 	</section>
 </th:block>

--- a/TESTdevcdper/src/main/resources/templates/fragments/plan/planSearch.html
+++ b/TESTdevcdper/src/main/resources/templates/fragments/plan/planSearch.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<th:block th:fragment="planSearch">
+	<!-- 검색 -->
+	<div class="card card-default">
+		<div class="card-body">
+			<section class="content" id="">
+				<div class="container-fluid">
+					<form action="coachingAdminPage">
+						<div class="row">
+							<div class="col-md-10 offset-md-1">
+								<div class="row">
+									<div class="col-3">
+										<div class="form-group">
+											<label>구분</label>
+											<select class="js-example-placeholder-single js-states form-control">
+												<option>전체</option>
+												<option>도움받기</option>
+												<option>혼자하기</option>
+											</select>
+										</div>
+									</div>
+									<div class="col-3">
+										<div class="form-group">
+											<label>상태</label>
+											<select class="js-example-placeholder-single js-states form-control">
+												<option selected="">전체</option>
+												<option>진행예정</option>
+												<option>진행중</option>
+												<option>중단</option>
+												<option>완료</option>
+											</select>
+										</div>
+									</div>
+									<div class="col-3">
+										<div class="form-group">
+											<label>기간선택</label>
+											<select class="js-example-placeholder-single js-states form-control">
+												<option selected="">전체</option>
+												<option>지난 1일</option>
+												<option>지난 1주</option>
+												<option>지난 1개월</option>
+												<option>지난 1년</option>
+												<!-- <option>기간 설정</option> -->
+											</select>
+										</div>
+									</div>
+									<div class="col-1">
+										<div class="form-group">
+											<label for="planDegree">차수</label>
+											<input type="number" id="planDegree" class="js-example-placeholder-single js-states form-control" placeholder="0"/>
+										</div>
+									</div>
+									<div class="col-2">
+										<div class="form-group">
+											<label>정렬</label>
+											<select class="js-example-placeholder-single js-states form-control">
+												<option selected="" data-select2-id="8">최신순</option>
+												<option>오래된순</option>
+											</select>
+										</div>
+									</div>
+								</div>
+								<div class="row">
+									<div class="col-2">
+										<div class="form-group">
+											<label>검색옵션</label>
+											<select class="js-example-placeholder-single js-states form-control">
+												<option selected="">전체</option>
+												<option>제목</option>
+												<option>내용</option>
+												<option>제목+내용</option>
+												<option>아이디(관리자)</option>
+											</select>
+										</div>
+									</div>
+									<div class="col-9" style="padding-right: 0px;">
+										<div class="form-group">
+											<label for="planSearch">검색</label>
+											<input type="search" id="planSearch" class="form-control form-control-lg" style="padding: 6px 12px; height: 37.99px;"
+												placeholder="검색어를 입력해주세요"/>
+										</div>
+									</div>
+									<div class="col-1" style="padding-left: 0px;">
+										<div class="form-group">
+											<button class="btn btn-lg btn-default btn-sm" style="padding: 6px 12px; margin-top: 32px; height: 37.99px;">
+												<i class="fa fa-search"></i>
+											</button>
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</form>
+				</div>
+			</section>
+		</div>
+	</div>
+	<!-- /검색-->
+</th:block>
+</html>

--- a/TESTdevcdper/src/main/resources/templates/fragments/plan/planTopSelect.html
+++ b/TESTdevcdper/src/main/resources/templates/fragments/plan/planTopSelect.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<th:block th:fragment="planTopSelect">
+	<div class="col-sm-10">
+		<div class="form-group float-sm-right col-5" id="planSelectMenu" style="padding-right: 20px; margin: 0px;min-width:364px;">
+			<select class="custom-select planSelect col-5">
+				<option>상위메뉴선택</option>
+				<option>통합계획</option>
+				<option>계획</option>
+				<option>상세계획</option>
+				<option>실천계획</option>
+			</select>&ensp;/&ensp;
+			<select class="custom-select planSelect col-6" disabled>
+				<option>하위메뉴선택</option>
+			</select>
+		</div>
+	</div><!-- /.col -->
+</th:block>
+</html>

--- a/TESTdevcdper/src/main/resources/templates/layout/default.html
+++ b/TESTdevcdper/src/main/resources/templates/layout/default.html
@@ -33,7 +33,10 @@
 	<!--헤더 메뉴 호버기능-->
 	<!--구글 폰트 전체 적용-->
 	<style>
-		#menu #dropLi:hover .dropdown-menu {
+		#dropLi:hover .dropdown-menu {
+			display: block;
+		}
+		.dropLi:hover .dropdown-menu {
 			display: block;
 		}
 		body {
@@ -103,8 +106,22 @@
 	<!-- chart js -->
 	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 	
-	<!-- ionicon -->
+	<!--planSelect js-->
+	<script type="text/javascript" th:src="@{/AdminLTE3/dist/js/plan/planSelect.js}"></script>
 	
+	<script type="text/javascript">
+		$(function(){
+			/* <![CDATA[ */
+			var className = "[[${className}]]"
+			var pathName = "[[${pathName}]]"
+			/* ]]> */
+			console.log(className);
+			$(className).parents('li').addClass('menu-open');
+			$(className).css({
+					'background-color' : '#323232'
+			});
+		});
+	</script>
 	<th:block layout:fragment="pageJavascript"></th:block>
 </body>
 </html>

--- a/TESTdevcdper/src/main/resources/templates/plan/mainPlan.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/mainPlan.html
@@ -1,297 +1,280 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"
-	  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-	  layout:decorator="layout/default">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorator="layout/default">
 <th:block layout:fragment="pageTitle">
 	<title th:text="${title}">Insert title here</title>
-	<input type="text" th:value="${mainCdp}" id="mainCdp" hidden/>
+	<input type="text" th:value="${mainCdp}" id="mainCdp" hidden />
 	<div class="col-sm-6">
 		<h1 class="m-0">나의 계획 한눈에보기</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-6">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{/totalPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'totalPlan'}"> 통합계획
-					</a>
-					<a th:href="@{/mainPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'plan'}"> 계획
-					</a>
-					<a th:href="@{/detailPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'detailPlan'}"> 상세계획
-					</a>
-					<a th:href="@{/actionPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'actionPlan'}"> 실천계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
 	<section class="content">
-	<div class="container-fluid"  th:align="center">
-		<!-- Default box -->
-		<div class="card col-md-8">
-			<div class="card-header">
-                <h3 class="card-title">나의 계획 한눈에보기</h3>
+		<div class="container-fluid" th:align="center">
+			<!-- Default box -->
+			<div class="card col-md-8">
+				<div class="card-header">
+					<h3 class="card-title">나의 계획 한눈에보기</h3>
 
-                <div class="card-tools">
-                  <div class="input-group input-group-sm" style="width: 150px;">
-                    <input type="text" name="table_search" class="form-control float-right" placeholder="통합계획검색">
+					<div class="card-tools">
+						<div class="input-group input-group-sm" style="width: 150px;">
+							<input type="text" name="table_search" class="form-control float-right"
+								placeholder="통합계획검색">
 
-                    <div class="input-group-append">
-                      <button type="submit" class="btn btn-default">
-                        <i class="fas fa-search"></i>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <!-- /.card-header -->
-			<div class="card-body table-responsive p-0">
-				<table class="table table-hover text-nowrap">
-		            <thead style="text-align: center;">
-		                <tr>
-		                    <th style="text-align: left;" class="col-2">통합계획명</th>
-	                        <th class="col-8">통합계획 팀프로젝트구현하기</th>
-	                        <th class="col-2">차수</th>
-		                </tr>
-		                <tr>
-		                    <th style="text-align: left;">
-		                    	<strong>
-		                    		기간
-		                    	</strong>
-		                    </th>
-	                        <th>
-								<a>2021.06.20 ~ </a>
-								<a>2021.08.06</a>
+							<div class="input-group-append">
+								<button type="submit" class="btn btn-default">
+									<i class="fas fa-search"></i>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+				<!-- /.card-header -->
+				<div class="card-body table-responsive p-0">
+					<table class="table table-hover text-nowrap">
+						<thead style="text-align: center;">
+							<tr>
+								<th style="text-align: left;" class="col-2">통합계획명</th>
+								<th class="col-8">통합계획 팀프로젝트구현하기</th>
+								<th class="col-2">차수</th>
+							</tr>
+							<tr>
+								<th style="text-align: left;">
+									<strong>
+										기간
+									</strong>
+								</th>
+								<th>
+									<a>2021.06.20 ~ </a>
+									<a>2021.08.06</a>
+									</td>
+								</th>
+								<th>2차</th>
+							</tr>
+						</thead>
+						<tbody class="col-9">
+							<tr>
+								<th>학력 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planEducationalHistory}">
+											<li>컴퓨터공학전공해서 취업하자</li>
+										</a>
+										<a th:href="@{/planEducationalHistory}">
+											<li>컴퓨터공학과 석사학위 취득</li>
+										</a>
+										<a th:href="@{/planEducationalHistory}">
+											<li>보안공학과를 통해서 보안쪽을 공부하자</li>
+										</a>
+										<a th:href="@{/planEducationalHistory}">
+											<li>독학학위제로 학위마련해서 정처기 따자</li>
+										</a>
+									</ul>
 								</td>
-	                        </th>
-	                        <th>2차</th>
-		                </tr>
-		            </thead>
-		            <tbody class="col-9">
-		                <tr>
-		                    <th>학력 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planEducationalHistory}">
-										<li>컴퓨터공학전공해서 취업하자</li>
-		                        	</a>
-		                        	<a th:href="@{/planEducationalHistory}">
-										<li>컴퓨터공학과 석사학위 취득</li>
-		                        	</a>
-		                        	<a th:href="@{/planEducationalHistory}">
-										<li>보안공학과를 통해서 보안쪽을 공부하자</li>
-		                        	</a>
-		                        	<a th:href="@{/planEducationalHistory}">
-										<li>독학학위제로 학위마련해서 정처기 따자</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                    <td>
-		                    	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                    </td>
-		                </tr>
-		                <tr>
-		                    <th>프로젝트 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planProject}">
-										<li>무료 캠핑장 정보를 얻을 수 있는 플랫폼</li>
-		                        	</a>
-		                        	<a th:href="@{/planProject}">
-										<li>드론을 활용해서 얻은 데이터로 정밀농업실현</li>
-		                        	</a>
-		                        	<a th:href="@{/planProject}">
-										<li>자바 기본문법을 활용한 계산기 만들기</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     		<li>2차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>자격증 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planCertificate}">
-										<li>취업에 정처기가 필수</li>
-										<li>정보보안기사취득해서 취업하고싶다.</li>
-										<li>네트워크관리사 2급 따자</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>공인어학 계획</th>
-		                    <td>
-		                        <ul>
-			                        <a th:href="@{/planCertifiedLanguage}">
-										<li>토익 스피킹 170점 달성이 목표</li>
-										<li>대기업입사를 위한 오픽 준비</li>
-			                        </a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>기술스택 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planTechnologyStack}">
-										<li>프로젝트를 완성하기 위한 JAVA 공부</li>
-		                        	</a>
-		                        	<a th:href="@{/planTechnologyStack}">
-										<li>프로젝트를 완성하기 위한 JAVASCRIPT 공부</li>
-		                        	</a>
-		                        	<a th:href="@{/planTechnologyStack}">
-										<li>DB전문 기술자가 되기위한 준비</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
- 		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>직종전문교육과정 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planJobTraining}">
-										<li>백앤드 개발자가 되기위한 과정</li>
-		                        	</a>
-		                        	<a th:href="@{/planJobTraining}">
-										<li>데이터 사이언티스트 취업에 꼭 필요한 핵심을 배울 수 있다.</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>인턴십 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planInternship}">
-										<li>당근마켓 정규직전환을 목표</li>
-		                        	</a>
-		                        	<a th:href="@{/planInternship}">
-										<li>업무경험으로 실무취약점 보완</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>공모전 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planContest}">
-										<li>KOPIS 빅데이터 분석 공모전</li>
-		                        	</a>
-		                        	<a th:href="@{/planContest}">
-										<li>2021 AI 블록체인 기술사업화 아이디어 경진대회</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>2차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		                <tr>
-		                    <th>경력 계획</th>
-		                    <td>
-		                        <ul>
-		                        	<a th:href="@{/planCareer}">
-										<li>우아한 형제들에 백엔드 개발자로 입사 목표</li>
-		                        	</a>
-		                        	<a th:href="@{/planCareer}">
-										<li>사내 시스템관련 어플리케이션 개발</li>
-		                        	</a>
-		                        	<a th:href="@{/planCareer}">
-										<li>카카오 근무</li>
-		                        	</a>
-								</ul>
-		                    </td>
-		                     <td>
-		                     	<ul>
-		                     		<li>1차</li>
-		                     		<li>1차</li>
-		                     	</ul>
-		                     </td>
-		                </tr>
-		            </tbody>
-		        </table>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>프로젝트 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planProject}">
+											<li>무료 캠핑장 정보를 얻을 수 있는 플랫폼</li>
+										</a>
+										<a th:href="@{/planProject}">
+											<li>드론을 활용해서 얻은 데이터로 정밀농업실현</li>
+										</a>
+										<a th:href="@{/planProject}">
+											<li>자바 기본문법을 활용한 계산기 만들기</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+										<li>2차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>자격증 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planCertificate}">
+											<li>취업에 정처기가 필수</li>
+											<li>정보보안기사취득해서 취업하고싶다.</li>
+											<li>네트워크관리사 2급 따자</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>공인어학 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planCertifiedLanguage}">
+											<li>토익 스피킹 170점 달성이 목표</li>
+											<li>대기업입사를 위한 오픽 준비</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>기술스택 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planTechnologyStack}">
+											<li>프로젝트를 완성하기 위한 JAVA 공부</li>
+										</a>
+										<a th:href="@{/planTechnologyStack}">
+											<li>프로젝트를 완성하기 위한 JAVASCRIPT 공부</li>
+										</a>
+										<a th:href="@{/planTechnologyStack}">
+											<li>DB전문 기술자가 되기위한 준비</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>직종전문교육과정 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planJobTraining}">
+											<li>백앤드 개발자가 되기위한 과정</li>
+										</a>
+										<a th:href="@{/planJobTraining}">
+											<li>데이터 사이언티스트 취업에 꼭 필요한 핵심을 배울 수 있다.</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>인턴십 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planInternship}">
+											<li>당근마켓 정규직전환을 목표</li>
+										</a>
+										<a th:href="@{/planInternship}">
+											<li>업무경험으로 실무취약점 보완</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>공모전 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planContest}">
+											<li>KOPIS 빅데이터 분석 공모전</li>
+										</a>
+										<a th:href="@{/planContest}">
+											<li>2021 AI 블록체인 기술사업화 아이디어 경진대회</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>2차</li>
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<th>경력 계획</th>
+								<td>
+									<ul>
+										<a th:href="@{/planCareer}">
+											<li>우아한 형제들에 백엔드 개발자로 입사 목표</li>
+										</a>
+										<a th:href="@{/planCareer}">
+											<li>사내 시스템관련 어플리케이션 개발</li>
+										</a>
+										<a th:href="@{/planCareer}">
+											<li>카카오 근무</li>
+										</a>
+									</ul>
+								</td>
+								<td>
+									<ul>
+										<li>1차</li>
+										<li>1차</li>
+									</ul>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<!-- /.card-body -->
 			</div>
-		<!-- /.card-body -->
+			<!-- /.card -->
 		</div>
-	<!-- /.card -->
-	</div>
 	</section>
-	
+
 
 
 </th:block>
 <th:block layout:fragment="pageJavascript">
-<script>
-	$(function(){
-		var mainCdp = $('#mainCdp').val();
-		if(mainCdp == "mainCdp"){
-			alert("경로가 mainCdp로 되어있습니다. 경로수정 하세요.");
-		};
-		$('table').find('li').css({
-			'list-style' : 'none'
-			,'text-align' : 'center'
-			,'padding-left' : '0px'
-		})
-		$('table').find('ul').css({
-			'padding-left' : '0px'
-		})
-		$('table').find('th').css({
-			'vertical-align' : 'middle'
-		})
-	});
-</script>
+	<script>
+		$(function () {
+			var mainCdp = $('#mainCdp').val();
+			if (mainCdp == "mainCdp") {
+				alert("경로가 mainCdp로 되어있습니다. 경로수정 하세요.");
+			};
+			$('table').find('li').css({
+				'list-style': 'none'
+				, 'text-align': 'center'
+				, 'padding-left': '0px'
+			})
+			$('table').find('ul').css({
+				'padding-left': '0px'
+			})
+			$('table').find('th').css({
+				'vertical-align': 'middle'
+			})
+		});
+	</script>
 </th:block>
+
 </html>

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planCareer.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planCareer.html
@@ -7,43 +7,15 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">경력 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planCertificate.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planCertificate.html
@@ -7,43 +7,14 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">자격증 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planCertifiedLanguage.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planCertifiedLanguage.html
@@ -7,43 +7,14 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">공인어학 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planContest.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planContest.html
@@ -7,43 +7,15 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">공모전 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planEducationalHistory.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planEducationalHistory.html
@@ -7,56 +7,24 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">학력 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
 <!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
+
 	<div class="card">
 		<div class="card-header">
 			<h3 class="card-title">
 				학력 계획
 			</h3>
-			
 			<div class="card-tools">
-				<a th:href="@{/addTotalPlan}">
-					<button type="button" class="btn btn-outline-primary">
-						등록하기
-					</button>
-				</a> 	
+				<a class="btn btn-outline-primary" th:href="@{/addTotalPlan(planName='학력계획')}">
+					등록하기
+				</a>
 				<button type="button" class="btn btn-tool" data-card-widget="collapse" title="Collapse">
 					<i class="fas fa-minus"></i>
 				</button>
@@ -416,8 +384,9 @@
 	
 </th:block>
 <th:block layout:fragment="pageJavascript">
-	<script>
+	<script type="text/javascript" th:inline="javascript">
 		$(document).ready(function(){
+			
 			/* parameter 영역 */
 			var table = $('.planTable');
 			var mainPlan = table.find('.mainPlan');

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planInternship.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planInternship.html
@@ -7,43 +7,14 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">인턴십 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planJobTraining.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planJobTraining.html
@@ -7,43 +7,14 @@
 	<div class="col-sm-2">
 		<p class="m-0" style="vertical-align: middle;">직종전문교육과정 계획</p>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planProject.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planProject.html
@@ -7,43 +7,14 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">프로젝트 계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/plan/planTechnologyStack.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/plan/planTechnologyStack.html
@@ -7,43 +7,14 @@
 	<div class="col-sm-2">
 		<h1 class="m-0">기술스택</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{planEducationalHistory}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'planEducationalHistory'}"> 학력 계획
-					</a>
-					<a th:href="@{/planProject}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'planProject'}"> 프로젝트 계획
-					</a>
-					<a th:href="@{/planCertificate}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertificate'}"> 자격증 계획
-					</a>
-					<a th:href="@{/planCertifiedLanguage}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCertifiedLanguage'}"> 공인어학 계획
-					</a>
-					<a th:href="@{/planTechnologyStack}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planTechnologyStack'}"> 기술스택 계획
-					</a>
-					<a th:href="@{/planJobTraining}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planJobTraining'}"> 직종전문교육과정 계획
-					</a>
-					<a th:href="@{/planInternship}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planInternship'}"> 인턴십 계획
-					</a>
-					<a th:href="@{/planContest}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planContest'}"> 공모전 계획
-					</a>
-					<a th:href="@{/planCareer}" class="btn btn-sm btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'planCareer'}"> 경력 계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 	
 </th:block>
 <th:block layout:fragment="pageJavascript">

--- a/TESTdevcdper/src/main/resources/templates/plan/totalPlan/totalPlan.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/totalPlan/totalPlan.html
@@ -7,28 +7,14 @@
 	<div class="col-sm-2">
 		<h1 class="m-0 koreafont">통합계획</h1>
 	</div><!-- /.col -->
-	<div class="col-sm-10">
-		<ol class="breadcrumb float-sm-right">
-			<div class="card-body table-responsive pad">
-				<div class="btn-group btn-group-toggle" data-toggle="buttons">
-					<a th:href="@{/totalPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a1" autocomplete="off" th:checked="${radioCheck == 'totalPlan'}"> 통합계획
-					</a>
-					<a th:href="@{/mainPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a2" autocomplete="off" th:checked="${radioCheck == 'plan'}"> 계획
-					</a>
-					<a th:href="@{/detailPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'detailPlan'}"> 상세계획
-					</a>
-					<a th:href="@{/actionPlan}" class="btn btn-outline-info">
-						<input type="radio" name="options" id="option_a3" autocomplete="off" th:checked="${radioCheck == 'actionPlan'}"> 실천계획
-					</a>
-				</div>
-			</div>
-		</ol>
-	</div><!-- /.col -->
+	<!-- 우측 상단 경로바 -->
+	<th:block th:replace="/fragments/plan/planTopSelect :: planTopSelect"></th:block>
 </th:block>
 <th:block layout:fragment="container">
+<!-- Default box -->
+
+	<!--계획 공통검색 기능-->
+	<th:block th:replace="/fragments/plan/planSearch :: planSearch"></th:block>
 	<!-- Default box -->
 	<div class="card">
 		<div class="card-header">
@@ -37,7 +23,7 @@
 			</h3>
 			
 			<div class="card-tools">
-				<a th:href="@{/addTotalPlan}">
+				<a th:href="@{/addTotalPlan(planName='통합계획')}">
 					<button type="button" class="btn btn-outline-primary">
 						등록하기
 					</button>
@@ -325,11 +311,6 @@
 <th:block layout:fragment="pageJavascript">
 	<script type="text/javascript" th:inline="javascript">
 		$(document).ready(function(){
-			
-			/* thmeleaf parameter 영역 */
-			/* <![CDATA[ */
-			/* var list = [[${status}]]; */
-			/* ]]> */
 			
 			/* parameter 영역 */
 			var table = $('.planTable');


### PR DESCRIPTION
author : 박승민

[ work complete]
- 레프트메뉴 고정기능 구현완료
- 계획부분 우측상단 경로 가이드 영역 select로 구현완료
- 검색바 추가
- 등록화면 작업

file :
[ templates ]
- default.html
- left.html
- header.html

[ static ]
- AdminLTE3/dist/js/plan/planSelect.js

[ java ]
- PlanInterceptor.java
- PlanConfig.java
- PlanController.java

detail :
::::::::::::::::::: java :::::::::::::::::::
- com.devcdper.interceptor					 : 패키지생성
- interceptor 패키지 하위 PlanInterceptor.java 	 : 인터셉터생성
- com.devcdper.config 						 : 패키지 생성
- config 패키지 하위 PlanConfig.java 			 : config파일 생성

[ interceptor / PlanInterceptor.java ]
- 컨트롤러완료후 실행되는 postHandle메서드에 소스코드 작업
- 요청 들어온 경로를 추출하고 “/”를 제거한 순수 경로문자열과
- left클래스명 검색에 사용하기위해 “.”과 순수경로문자열을 결합하여
- ModelAndView에 등록.(addObject활용)

[ config / PlanConfig.java ]
- PlanInterceptor 의존성 주입
- 모든경로 PlanInterceptor 거치도록 설정
- /AdminLTE3/** 제외
- /js/** 제외

[ plan.controller / PlanController.java ]
- model에 담던 이전 radioCheck 변수 제거
- 계획 등록화면 공동사용을 위한 변수 설정(planName)


::::::::::::::::::: templates :::::::::::::::::::
[ layout / default.html ]
- 레프트메뉴 고정 완료
- hover기능 #menu 식별자 제거 : left메뉴 뿐만이아닌
   body영역에서도 호버기능을 사용하기 위해 제거
- id가 아닌 class로 검색하기 위해 호버css 추가
- planSelect script경로 설정
- 하단 script : 레프트메뉴 고정을 위한 코드 작성

[ fragments / left.html ]
- 레프트메뉴 고정을 위한 작업실시
- 레프트바중 클릭시 나타나는 하위메뉴들 각각의 li에 클래스명 추가
- 클래스명은 해당 경로명과 같도록 함
- 전체 코드 들여쓰기
- 자동들여쓰기 방법은 window(Ctrl + Shift + F) / mac(commend + Shift + F)
- 계획, 상세계획, 실천계획 전부 클래스명 설정

[ fragments / header.html ]
- 전체 코드 들여쓰기

[ fragments / planSearch.html ]
- 계획 검색바 분리

[ plan / plan / 하위.html ]
- 상단 경로바 radio group >> fragments / plan / planTopSelect.html을 replace
하도록 변경
- 상단 검색바 fragments / plan / planSearch.html을 replace 하도록 변경

[ plan / totalPlan / 하위.html]
- addTotalPlan, modifyTotalPlan >> 상단 경로 바 제거후 fragments / plan 폴더 하위로
이동
- 상단 경로바 fragments / plan / planTopSelect.html을 replace 하도록 변경
- 상단 검색바 fragments / plan / planSearch.html을 replace 하도록 변경

[ plan / mainPlan.html ]
- 전체 코드 들여쓰기
- 상단 경로바  fragments / plan / planTopSelect.html을 replace 하도록 변경


::::::::::::::::::: static :::::::::::::::::::
[ AdminLTE3/dist/js/plan/planSelect.js ]
- 계획관련 html 상단 경로바 JavaScript or jQuery 작업
- 상위메뉴에 따른 각각의 해당 하위메뉴 노출기능 구현
- 하위메뉴 각각의 경로로 이동할 수 있도록 Script사용하여 경로 설정
- pix기능 구현 (x)