### PR TITLE
[03team] devcdper v11 teamproject 5차셋팅 - RJH

### DIFF
--- a/TESTdevcdper/src/main/java/com/devcdper/plan/controller/DetailPlanController.java
+++ b/TESTdevcdper/src/main/java/com/devcdper/plan/controller/DetailPlanController.java
@@ -130,34 +130,96 @@ public class DetailPlanController {
 	//AJAX1 통합계획 선택시//
 	@RequestMapping(value = "/totalPlanSelected", method=RequestMethod.POST)
 	@ResponseBody
-	public List<PlanDto> totalPlanSelected(@RequestParam(value="stotalPlanCode",required=true)String stotalPlanCode){
+	public Map<String, Object> totalPlanSelected(@RequestParam(value="stotalPlanCode",required=true)String stotalPlanCode
+										  ,@RequestParam(value="planName",required = true)String planName){
 		System.out.println(stotalPlanCode+" <- AJAX1 controller");
 		//String result = totalPlanCode+ "AJAX return 성공";
+		System.out.println(planName+"  palnNameController");
+		Map<String, Object> detailPlanMap = new HashMap<String, Object>();
 		
-		//List<PlanDto> planDto = null;
 		
-		List<PlanDto> getEduTitleSearch = detailPlanService.getEduTotalTitleSearch(stotalPlanCode);
-		//if(stotalPlanCode.equals(anObject))
+		if(planName.equals("planEducationalHistoryDetail") && planName != null && !"".equals(planName)) {
+			System.out.println("planEducationalHistoryDetail 컨트롤러1 접근성공");
+			detailPlanMap.put("planEducationalHistoryDetail", detailPlanService.getEducationalHistoryTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planProjectDetail")&& planName != null && !"".equals(planName)){
+			System.out.println("planProjectDetail 컨트롤러1 접근성공");
+			detailPlanMap.put("planProjectDetail",detailPlanService.getProjectTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planCertificateDetail")&& planName != null && !"".equals(planName)) {
+			System.out.println("자격증 컨트롤러 ajax접근성공");
+			detailPlanMap.put("planCertificateDetail",detailPlanService.getCertificateTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planCertifiedLanguageDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planCertifiedLanguageDetail",detailPlanService.getCertifiedLanguageTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planTechnologyStackDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planTechnologyStackDetail",detailPlanService.getTechnologyStackTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planJobTrainingDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planJobTrainingDetail",detailPlanService.getJobTrainingTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planInternshipDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planInternshipDetail",detailPlanService.getInternshipTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planContestDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planContestDetail",detailPlanService.getContestTotalTitleSearch(stotalPlanCode));
+			
+		}else if(planName.equals("planCareerDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planCareerDetail",detailPlanService.getCareerTotalTitleSearch(stotalPlanCode));
+			
+		}
+		//okay 임의의 Email값 넘겨(각 화면의 컨트롤러) totalPlan의 모든 값중 Code와 Title가져오면된다.
 		//List<PlanDto> getProjTitleSearch = detailPlanService.getProjTotalTitleSearch(stotalPlanCode);
-		//어떻게하면 페이지에 따라 서치 타이틀을 쓸 수 있을 가? 서치키벨류?
-		return  getEduTitleSearch;///planDto;
-				
+		
+		return  detailPlanMap;
 	}
 	
 	
 	//AJAX2 계획 선택후 검색 클릭시//
 	@RequestMapping(value = "/totalAndPlanSelected", method=RequestMethod.POST)
 	@ResponseBody
-	public List<DetailPlanDto> totalAndPlanSelected(@RequestParam(value="totalPlanCode",required=true)String totalPlanCode
-											 ,@RequestParam(value="planCode",required =true )String planCode){
+	public Map<String, Object> totalAndPlanSelected(@RequestParam(value="totalPlanCode",required=true)String totalPlanCode
+											 ,@RequestParam(value="planCode",required =true )String planCode
+											 ,@RequestParam(value="planName",required = true)String planName){
 		System.out.println(totalPlanCode+" <- AJAX2 controller");
 		System.out.println(planCode+" <- AJAX2 controller");
+		System.out.println(planName+"palnNameAJAX2Controller");
+		Map<String, Object> detailPlanMap = new HashMap<String, Object>();
 		
+		if(planName.equals("planEducationalHistoryDetail")&& planName != null && !"".equals(planName)) {
+			System.out.println("planEducationalHistoryDetail AJAX2 컨트롤러 접근성공");
+			detailPlanMap.put("planEducationalHistoryDetail",detailPlanService.getEducationalHistoryDetailPlanList(totalPlanCode,planCode));
+			
+		}else if(planName.equals("planProjectDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planProjectDetail",detailPlanService.getProjectDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planCertificateDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planCertificateDetail",detailPlanService.getCertificateDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planCertifiedLanguageDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planCertifiedLanguageDetail",detailPlanService.getCertifiedLanguageDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planTechnologyStackDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planTechnologyStackDetail",detailPlanService.getTechnologyStackDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planJobTrainingDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planJobTrainingDetail",detailPlanService.getJobTrainingDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planInternshipDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planInternshipDetail",detailPlanService.getInternshipDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planContestDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planContestDetail",detailPlanService.getContestDetailPlanList(totalPlanCode, planCode));
+			
+		}else if(planName.equals("planCareerDetail")&& planName != null && !"".equals(planName)) {
+			detailPlanMap.put("planCareerDetail",detailPlanService.getCareerDetailPlanList(totalPlanCode, planCode));
+			
+		}
 		
-		List<DetailPlanDto> detailPlanList = detailPlanService.getDetailPlanList(totalPlanCode,planCode);
+		//List<DetailPlanDto> detailPlanList = detailPlanService.getDetailPlanList(totalPlanCode,planCode);
 		
-		
-		return detailPlanList;
+		return detailPlanMap;
 	}
 
 	
@@ -176,26 +238,26 @@ public class DetailPlanController {
 	/*--------------------------------------::: 프로젝트 상세 계획 관리 Start :::----------------------------*/
 	//프로젝트 상세 계획 관리
 	@GetMapping("/planProjectDetail")
-	public String planProjectDetail(Model model, String paramList) {
+	public String planProjectDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planProjectDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planProjectDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailProjectjPlanList = detailPlanService.getProjectDetailPlanList(paramList);
+		//List<DetailPlanDto> detailProjectjPlanList = detailPlanService.getProjectDetailPlanList(paramList);
 		
 		
-//		String userEmail= "park01@hanmail.net";
-//		String searchKey="user_email";
-//		String searchValue=userEmail;
-//		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
 		
 		
 		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		//model.addAttribute("totalPlanList",totalPlanList);
-		model.addAttribute("detailProjectjPlanList",detailProjectjPlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailProjectjPlanList",detailProjectjPlanList);
 		
 		return "plan/detailPlan/planProjectDetail";
 	}
@@ -226,37 +288,30 @@ public class DetailPlanController {
 	/*--------------------------------------::: 자격증 상세 계획 관리 Start :::-------------------------*/
 	//자격증 상세 계획 관리
 	@GetMapping("/planCertificateDetail")
-	public String planCertificateDetail(Model model, String paramList) {
+	public String planCertificateDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planCertificateDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planCertificateDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailCertificatePlanList = detailPlanService.getCertificateDetailPlanList(paramList);
+		//List<DetailPlanDto> detailCertificatePlanList = detailPlanService.getCertificateDetailPlanList(paramList);
+		
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
 		
 		
-		
-		
-		model.addAttribute("title", "자격증 상세 계획");
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailCertificatePlanList",detailCertificatePlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailCertificatePlanList",detailCertificatePlanList);
 		
 		
 		return "plan/detailPlan/planCertificateDetail";
 	}
-	/*----------------------------------------- 자격증 상세 계획 관리 등록 Start ----------------------------*/
-	@GetMapping("/addPlanCertificateDetail")
-	public String addPlanCertificateDetail(Model model) {
-		model.addAttribute("title", "자격증 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanCertificateDetail";
-	}
-	@PostMapping("/addPlanCertificateDetail")
-	public String addPlanCertificateDetail() {
-		return "redirect:/planCertificateDetail";
-	}
-	/*----------------------------------------- 자격증 상세 계획 관리 등록 End ----------------------------*/
+	
 	/*----------------------------------------- 자격증 상세 계획 관리 수정 Start ----------------------------*/
 	@GetMapping("/modifyPlanCertificateDetail")
 	public String modifyPlanCertificateDetail(Model model){
@@ -280,33 +335,29 @@ public class DetailPlanController {
 	/*--------------------------------------::: 공인어학 상세 계획 관리Start :::-------------------------*/
 	//공인어학 상세 계획 관리
 	@GetMapping("/planCertifiedLanguageDetail")
-	public String planCertifiedLanguageDetail(Model model, String paramList) {
+	public String planCertifiedLanguageDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planCertifiedLanguageDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planCertifiedLanguageDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailCertifiedLanguagePlanList=detailPlanService.getCertifiedLanguageDetailPlanList(paramList);
+		//List<DetailPlanDto> detailCertifiedLanguagePlanList=detailPlanService.getCertifiedLanguageDetailPlanList(paramList);
 		
-		model.addAttribute("title", "공인어학 상세 계획");
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		
+		
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailCertifiedLanguagePlanList",detailCertifiedLanguagePlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailCertifiedLanguagePlanList",detailCertifiedLanguagePlanList);
 		
 		return "plan/detailPlan/planCertifiedLanguageDetail";
 	}
-	/*----------------------------------------- 공인어학 상세 계획 관리 등록 Start ----------------------------*/
-	@GetMapping("/addPlanCertifiedLanguageDetail")
-	public String addPlanCertifiedLanguageDetail(Model model) {
-		model.addAttribute("title", "공인어학 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanCertifiedLanguageDetail";
-	}
-	@PostMapping("/addPlanCertifiedLanguageDetail")
-	public String addPlanCertifiedLanguageDetail() {
-		return "redirect:/planCertifiedLanguageDetail";
-	}
-	/*----------------------------------------- 공인어학 상세 계획 관리 등록 End ----------------------------*/
+	
 	/*----------------------------------------- 공인어학 상세 계획 관리 수정 Start ----------------------------*/
 	@GetMapping("/modifyPlanCertifiedLanguageDetail")
 	public String modifyPlanCertifiedLanguageDetail(Model model){
@@ -330,34 +381,30 @@ public class DetailPlanController {
 	/*--------------------------------------::: 기술스택 상세 계획 관리 Start :::------------------------*/
 	//기술스택 상세 계획 관리
 	@GetMapping("/planTechnologyStackDetail")
-	public String planTechnologyStackDetail(Model model, String paramList) {
+	public String planTechnologyStackDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planTechnologyStackDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planTechnologyStackDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailTechnologyStackPlanList=detailPlanService.getTechnologyStackDetailPlanList(paramList);
+		//List<DetailPlanDto> detailTechnologyStackPlanList=detailPlanService.getTechnologyStackDetailPlanList(paramList);
 		
-		model.addAttribute("title", "기술스택 상세 계획");
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		
+		
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailTechnologyStackPlanList",detailTechnologyStackPlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailTechnologyStackPlanList",detailTechnologyStackPlanList);
 		
 		
 		return "plan/detailPlan/planTechnologyStackDetail";
 	}
-	/*----------------------------------------- 기술스택 상세 계획 관리 등록 Start ---------------------------*/
-	@GetMapping("/addPlanTechnologyStackDetail")
-	public String addPlanTechnologyStackDetail(Model model) {
-		model.addAttribute("title", "기술스택 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanTechnologyStackDetail";
-	}
-	@PostMapping("/addPlanTechnologyStackDetail")
-	public String addPlanTechnologyStackDetail() {
-		return "redirect:/planTechnologyStackDetail";
-	}
-	/*----------------------------------------- 기술스택 상세 계획 관리 등록 End ---------------------------*/
+	
 	/*----------------------------------------- 기술스택 상세 계획 관리 수정 Start ---------------------------*/
 	@GetMapping("/modifyPlanTechnologyStackDetail")
 	public String modifyPlanTechnologyStackDetail(Model model){
@@ -380,34 +427,30 @@ public class DetailPlanController {
 	/*--------------------------------------::: 직종전문교육과정 상세 계획 관리 Start :::-------------------------*/
 	//직종전문교육과정 상세 계획 관리
 	@GetMapping("/planJobTrainingDetail")
-	public String planJobTrainingDetail(Model model, String paramList) {
+	public String planJobTrainingDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planJobTrainingDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planJobTrainingDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailJobTrainingPlanList=detailPlanService.getJobTrainingDetailPlanList(paramList);
+		//List<DetailPlanDto> detailJobTrainingPlanList=detailPlanService.getJobTrainingDetailPlanList(paramList);
 		
-		model.addAttribute("title", "직종전문교육과정 상세 계획");
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		
+		
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailJobTrainingPlanList", detailJobTrainingPlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailJobTrainingPlanList", detailJobTrainingPlanList);
 		
 		
 		return "plan/detailPlan/planJobTrainingDetail";
 	}
-	/*----------------------------------------- 직종전문교육과정 상세 계획 관리 등록 Start ----------------------------*/
-	@GetMapping("/addPlanJobTrainingDetail")
-	public String addPlanJobTrainingDetail(Model model) {
-		model.addAttribute("title", "직종전문교육과정 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanJobTrainingDetail";
-	}
-	@PostMapping("/addPlanJobTrainingDetail")
-	public String addPlanJobTrainingDetail() {
-		return "redirect:/planJobTrainingDetail";
-	}
-	/*----------------------------------------- 직종전문교육과정 상세 계획 관리 등록 End ----------------------------*/
+	
 	/*----------------------------------------- 직종전문교육과정 상세 계획 관리 수정 Start ----------------------------*/
 	@GetMapping("/modifyPlanJobTrainingDetail")
 	public String modifyPlanJobTrainingDetail(Model model){
@@ -431,34 +474,30 @@ public class DetailPlanController {
 	/*--------------------------------------::: 인턴십 상세 계획 관리 Start :::------------------------*/
 	//인턴십 상세 계획 관리
 	@GetMapping("/planInternshipDetail")
-	public String planInternshipDetail(Model model, String paramList) {
+	public String planInternshipDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planInternshipDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planInternshipDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailInternshipPlanList=detailPlanService.getInternshipDetailPlanList(paramList);
+		//List<DetailPlanDto> detailInternshipPlanList=detailPlanService.getInternshipDetailPlanList(paramList);
 		
-		model.addAttribute("title", "인턴십 상세 계획");
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		
+		
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailInternshipPlanList", detailInternshipPlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailInternshipPlanList", detailInternshipPlanList);
 		
 		
 		return "plan/detailPlan/planInternshipDetail";
 	}
-	/*----------------------------------------- 인턴십 상세 계획 관리 등록 Start ---------------------------*/
-	@GetMapping("/addPlanInternshipDetail")
-	public String addPlanInternshipDetail(Model model) {
-		model.addAttribute("title", "인턴십 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanInternshipDetail";
-	}
-	@PostMapping("/addPlanInternshipDetail")
-	public String addPlanInternshipDetail() {
-		return "redirect:/planInternshipDetail";
-	}
-	/*----------------------------------------- 인턴십 상세 계획 관리 등록 End ---------------------------*/
+	
 	/*----------------------------------------- 인턴십 상세 계획 관리 수정 Start ---------------------------*/
 	@GetMapping("/modifyPlanInternshipDetail")
 	public String modifyPlanInternshipDetail(Model model){
@@ -482,33 +521,29 @@ public class DetailPlanController {
 	/*--------------------------------------::: 공모전 상세 계획 관리 Start :::------------------------*/
 	//공모전 상세 계획 관리
 	@GetMapping("/planContestDetail")
-	public String planContestDetail(Model model, String paramList) {
+	public String planContestDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planContestDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planContestDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailContestPlanList=detailPlanService.getContestDetailPlanList(paramList);
+		//List<DetailPlanDto> detailContestPlanList=detailPlanService.getContestDetailPlanList(paramList);
 		
-		model.addAttribute("title", "공모전 상세 계획");
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		
+		
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailContestPlanList", detailContestPlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailContestPlanList", detailContestPlanList);
 		
 		return "plan/detailPlan/planContestDetail";
 	}
-	/*----------------------------------------- 공모전 상세 계획 관리 등록 Start ---------------------------*/
-	@GetMapping("/addPlanContestDetail")
-	public String addPlanContestDetail(Model model) {
-		model.addAttribute("title", "공모전 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanContestDetail";
-	}
-	@PostMapping("/addPlanContestDetail")
-	public String addPlanContestDetail() {
-		return "redirect:/planContestDetail";
-	}
-	/*----------------------------------------- 공모전 상세 계획 관리 등록 End ---------------------------*/
+	
 	/*----------------------------------------- 공모전 상세 계획 관리 수정 Start ---------------------------*/
 	@GetMapping("/modifyPlanContestDetail")
 	public String modifyPlanContestDetail(Model model){
@@ -532,33 +567,29 @@ public class DetailPlanController {
 	/*--------------------------------------::: 경력 상세 계획 관리 Start :::-------------------------*/
 	//경력 상세 계획 관리
 	@GetMapping("/planCareerDetail")
-	public String planCareerDetail(Model model, String paramList) {
+	public String planCareerDetail(Model model) {//, String paramList
 		//log.info("==============================================");
 		//log.info("planCareerDetail 메서드 실행");
 		//log.info("==============================================");
 		System.out.println("==============================================");
 		System.out.println("planCareerDetail 메서드 실행");
 		System.out.println("==============================================");
-		List<DetailPlanDto> detailCareerPlanList=detailPlanService.getCareerDetailPlanList(paramList);
+		//List<DetailPlanDto> detailCareerPlanList=detailPlanService.getCareerDetailPlanList(paramList);
 		
-		model.addAttribute("title", "경력 상세 계획");
+		String userEmail= "park01@hanmail.net";
+		String searchKey="user_email";
+		String searchValue=userEmail;
+		List<PlanDto> totalPlanList = planService.getTotalPlan(searchKey, searchValue);
+		
+		
+		model.addAttribute("title", "프로젝트 상세 계획");
 		model.addAttribute("function", "plan");			//기능별 left 메뉴노출
-		model.addAttribute("detailCareerPlanList", detailCareerPlanList);
+		model.addAttribute("totalPlanList",totalPlanList);
+		//model.addAttribute("detailCareerPlanList", detailCareerPlanList);
 		
 		return "plan/detailPlan/planCareerDetail";
 	}
-	/*----------------------------------------- 경력 상세 계획 관리 등록 Start ----------------------------*/
-	@GetMapping("/addPlanCareerDetail")
-	public String addPlanCareerDetail(Model model) {
-		model.addAttribute("title", "경력 상세 계획 ");
-		model.addAttribute("function", "none");
-		return "plan/detailPlan/addPlanCareerDetail";
-	}
-	@PostMapping("/addPlanCareerDetail")
-	public String addPlanCareerDetail() {
-		return "redirect:/planCareerDetail";
-	}
-	/*----------------------------------------- 경력 상세 계획 관리 등록 End ----------------------------*/
+	
 	/*----------------------------------------- 경력 상세 계획 관리 수정 Start ----------------------------*/
 	@GetMapping("/modifyPlanCareerDetail")
 	public String modifyPlanCareerDetail(Model model){

--- a/TESTdevcdper/src/main/java/com/devcdper/plan/dao/DetailPlanMapper.java
+++ b/TESTdevcdper/src/main/java/com/devcdper/plan/dao/DetailPlanMapper.java
@@ -18,28 +18,53 @@ public interface DetailPlanMapper {
 	
 	
 	//프로젝트 상세 계획 리스트
-	public List<DetailPlanDto> getProjectDetailPlanList(String paramList);
+	//public List<DetailPlanDto> getProjectDetailPlanList(String paramList);
+	public List<DetailPlanDto> getProjectDetailPlanList(String totalPlanCode,String planCode);
 	
 	//자격증 상세 계획 리스트
-	public List<DetailPlanDto> getCertificateDetailPlanList(String paramList);
+	public List<DetailPlanDto> getCertificateDetailPlanList(String totalPlanCode,String planCode);
 	//공인어학 상세 계획 리스트
-	public List<DetailPlanDto> getCertifiedLanguageDetailPlanList(String paramList);
+	public List<DetailPlanDto> getCertifiedLanguageDetailPlanList(String totalPlanCode,String planCode);
 	//기술스택 상세 계획 리스트
-	public List<DetailPlanDto> getTechnologyStackDetailPlanList(String paramList);
+	public List<DetailPlanDto> getTechnologyStackDetailPlanList(String totalPlanCode,String planCode);
 	//직종전문교육과정 상세 계획 리스트
-	public List<DetailPlanDto> getJobTrainingDetailPlanList(String paramList);
+	public List<DetailPlanDto> getJobTrainingDetailPlanList(String totalPlanCode,String planCode);
 	//인턴십 상세 계획 리스트
-	public List<DetailPlanDto> getInternshipDetailPlanList(String paramList);
+	public List<DetailPlanDto> getInternshipDetailPlanList(String totalPlanCode,String planCode);
 	//공모전 상세 계획 리스트
-	public List<DetailPlanDto> getContestDetailPlanList(String paramList);
+	public List<DetailPlanDto> getContestDetailPlanList(String totalPlanCode,String planCode);
 	//경력 상세 계획 리스트
-	public List<DetailPlanDto> getCareerDetailPlanList(String paramList);
+	public List<DetailPlanDto> getCareerDetailPlanList(String totalPlanCode,String planCode);
 	
 	
 	//타이틀 서치 (통합계획 선택)
 	//학력 상세 계획 타이틀 서치
-	public List<PlanDto> getEduTotalTitleSearch(String stotalPlanCode);
+	public List<PlanDto> getEducationalHistoryTotalTitleSearch(String stotalPlanCode);
 	
 	//프로젝트 상세 계획 타이틀 서치
-	public List<PlanDto> getProjTotalTitleSearch(String stotalPlanCode);
+	public List<PlanDto> getProjectTotalTitleSearch(String stotalPlanCode);
+	
+	//자격증 상세 계획 타이틀 서치  
+	public List<PlanDto> getCertificateTotalTitleSearch(String stotalPlanCode);
+	
+	//공인어학 상세 계획 타이틀 서치 
+	public List<PlanDto> getCertifiedLanguageTotalTitleSearch(String stotalPlanCode);
+	//기술스택 상세 계획 타이틀 서치
+	public List<PlanDto> getTechnologyStackTotalTitleSearch(String stotalPlanCode);
+	//직종전문교육과정 상세 타이틀 서치
+	public List<PlanDto> getJobTrainingTotalTitleSearch(String stotalPlanCode);
+	//인턴십 상세 계획 타이틀 서치
+	public List<PlanDto> getInternshipTotalTitleSearch(String stotalPlanCode);
+	
+	//공모전 상세 계획 타이틀 서치
+	public List<PlanDto> getContestTotalTitleSearch(String stotalPlanCode);
+	//경력 상세 계획 타이틀 서치
+	public List<PlanDto> getCareerTotalTitleSearch(String stotalPlanCode);
+	
+	
+	
+	
+	
+	
+	
 }

--- a/TESTdevcdper/src/main/java/com/devcdper/plan/service/DetailPlanService.java
+++ b/TESTdevcdper/src/main/java/com/devcdper/plan/service/DetailPlanService.java
@@ -7,6 +7,7 @@ import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.devcdper.plan.dao.DetailPlanMapper;
 import com.devcdper.plan.domain.DetailPlanDto;
@@ -14,6 +15,7 @@ import com.devcdper.plan.domain.PlanDto;
 
 
 @Service
+@Transactional
 public class DetailPlanService {
 	
 	private final DetailPlanMapper detailPlanMapper;
@@ -41,54 +43,58 @@ public class DetailPlanService {
 //
 //	}
 	
-	//상세 계획 별(?)리스트 // 학력 상세 계획 
-	public List<DetailPlanDto> getDetailPlanList(String totalPlanCode,String planCode){// String totalPlanCode,String planCode                  
-		//if(request.){}
-		List<DetailPlanDto> detailPlanList = detailPlanMapper.getEducationalHistoryDetailPlanList(totalPlanCode, planCode);                   
+	//학력 상세 계획 리스트 
+	public List<DetailPlanDto> getEducationalHistoryDetailPlanList(String totalPlanCode,String planCode){// String totalPlanCode,String planCode                  
+		//if(request.getRUI...?){}
+		
+		List<DetailPlanDto> getEducationalHistoryDetailPlanList = detailPlanMapper.getEducationalHistoryDetailPlanList(totalPlanCode, planCode);
+		
 		System.out.println(totalPlanCode+" <- AJAX2 service");
 		System.out.println(planCode+" <- AJAX2 service");
-		return detailPlanList;
+		return getEducationalHistoryDetailPlanList;
 
 	}
 	
 	//프로젝트 상세 계획
-	public List<DetailPlanDto> getProjectDetailPlanList(String paramList){
-		List<DetailPlanDto> detailProjectPlanList = detailPlanMapper.getProjectDetailPlanList(paramList);
+	public List<DetailPlanDto> getProjectDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailProjectPlanList = detailPlanMapper.getProjectDetailPlanList(totalPlanCode, planCode);
+		//System.out.println("프로젝트상세계획 가져오남?");
 		return detailProjectPlanList;
 	}
+	
 	//자격증 상세 계획
-	public List<DetailPlanDto> getCertificateDetailPlanList(String paramList){
-		List<DetailPlanDto> detailCertificatePlanList=detailPlanMapper.getCertificateDetailPlanList(paramList);
+	public List<DetailPlanDto> getCertificateDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailCertificatePlanList=detailPlanMapper.getCertificateDetailPlanList(totalPlanCode,planCode);
 		return detailCertificatePlanList;
 	}
 	//공인어학 상세 계획
-	public List<DetailPlanDto> getCertifiedLanguageDetailPlanList(String paramList){
-		List<DetailPlanDto> detailCertifiedLanguagePlanList=detailPlanMapper.getCertifiedLanguageDetailPlanList(paramList);
+	public List<DetailPlanDto> getCertifiedLanguageDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailCertifiedLanguagePlanList=detailPlanMapper.getCertifiedLanguageDetailPlanList(totalPlanCode,planCode);
 		return detailCertifiedLanguagePlanList;
 	}
 	//기술스택 상세 계획
-	public List<DetailPlanDto> getTechnologyStackDetailPlanList(String paramList){
-		List<DetailPlanDto> detailTechnologyStackPlanList=detailPlanMapper.getTechnologyStackDetailPlanList(paramList);
+	public List<DetailPlanDto> getTechnologyStackDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailTechnologyStackPlanList=detailPlanMapper.getTechnologyStackDetailPlanList(totalPlanCode,planCode);
 		return detailTechnologyStackPlanList;
 	}
 	//직종전문교육과정 상세 계획
-	public List<DetailPlanDto> getJobTrainingDetailPlanList(String paramList){
-		List<DetailPlanDto> detailJobTrainingPlanList=detailPlanMapper.getJobTrainingDetailPlanList(paramList);
+	public List<DetailPlanDto> getJobTrainingDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailJobTrainingPlanList=detailPlanMapper.getJobTrainingDetailPlanList(totalPlanCode,planCode);
 		return detailJobTrainingPlanList;
 	}
 	//인턴십 상세 계획
-	public List<DetailPlanDto> getInternshipDetailPlanList(String paramList){
-		List<DetailPlanDto> detailInternshipPlanList=detailPlanMapper.getInternshipDetailPlanList(paramList);
+	public List<DetailPlanDto> getInternshipDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailInternshipPlanList=detailPlanMapper.getInternshipDetailPlanList(totalPlanCode,planCode);
 		return detailInternshipPlanList;
 	}
 	//공모전 상세 계획
-	public List<DetailPlanDto> getContestDetailPlanList(String paramList){
-		List<DetailPlanDto> detailContestPlanList=detailPlanMapper.getContestDetailPlanList(paramList);
+	public List<DetailPlanDto> getContestDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailContestPlanList=detailPlanMapper.getContestDetailPlanList(totalPlanCode,planCode);
 		return detailContestPlanList;
 	}
 	//경력 상세 계획
-	public List<DetailPlanDto> getCareerDetailPlanList(String paramList){
-		List<DetailPlanDto> detailCareerPlanList=detailPlanMapper.getCareerDetailPlanList(paramList);
+	public List<DetailPlanDto> getCareerDetailPlanList(String totalPlanCode,String planCode){
+		List<DetailPlanDto> detailCareerPlanList=detailPlanMapper.getCareerDetailPlanList(totalPlanCode,planCode);
 		return detailCareerPlanList;
 	}
 	
@@ -99,15 +105,51 @@ public class DetailPlanService {
 	
 	//통합계획 선택 서비스
 	//학력 상세 계획
-	public List<PlanDto> getEduTotalTitleSearch(String stotalPlanCode){
-		return detailPlanMapper.getEduTotalTitleSearch(stotalPlanCode);
+	public List<PlanDto> getEducationalHistoryTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getEducationalHistoryTotalTitleSearch(stotalPlanCode);
 	}
 	
 	//프로젝트 상세 계획
-	public List<PlanDto> getProjTotalTitleSearch(String stotalPlanCode){
-		return detailPlanMapper.getProjTotalTitleSearch(stotalPlanCode);
+	public List<PlanDto> getProjectTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getProjectTotalTitleSearch(stotalPlanCode);
 	}
 	
-	
+	//자격증 상세 계획
+	public List<PlanDto> getCertificateTotalTitleSearch(String stotalPlanCode){
+		System.out.println("자격증 서비스 서치 접근 성공");
+		return detailPlanMapper.getCertificateTotalTitleSearch(stotalPlanCode);
+	}
+	//공인어학 상세 계획
+	public List<PlanDto> getCertifiedLanguageTotalTitleSearch(String stotalPlanCode){
+		System.out.println("공인어학 서비스 서치 접근 성공");
+		return detailPlanMapper.getCertifiedLanguageTotalTitleSearch(stotalPlanCode);
+	}
+	//기술스택 상세 계획
+	public List<PlanDto> getTechnologyStackTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getTechnologyStackTotalTitleSearch(stotalPlanCode);
+	}
+	//직종전문교육과정 상세 계획
+	public List<PlanDto> getJobTrainingTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getJobTrainingTotalTitleSearch(stotalPlanCode);
+	}
+	//인턴십 상세 계획
+	public List<PlanDto> getInternshipTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getInternshipTotalTitleSearch(stotalPlanCode);
+	}
+	//공모전 상세 계획
+	public List<PlanDto> getContestTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getContestTotalTitleSearch(stotalPlanCode);
+	}
+	//경력 상세 계획
+	public List<PlanDto> getCareerTotalTitleSearch(String stotalPlanCode){
+		System.out.println("서비스 서치 접근 성공");
+		return detailPlanMapper.getCareerTotalTitleSearch(stotalPlanCode);
+	}
 	
 }

--- a/TESTdevcdper/src/main/resources/mapper/DetailPlanMapper.xml
+++ b/TESTdevcdper/src/main/resources/mapper/DetailPlanMapper.xml
@@ -57,8 +57,9 @@
 		FROM 
 			ypr821.plan_project_detail 
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_project_code='plan_project_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_project_code=#{planCode};
 	</select>
+	<!-- 'total_plan_code_01' 'plan_project_code_01'-->
 	
 	<!--자격증 상세 계획  -->
 	<select  id="getCertificateDetailPlanList" parameterType="String" resultType="com.devcdper.plan.domain.DetailPlanDto" resultMap ="detailPlanResultMap" fetchSize="1000">
@@ -81,7 +82,7 @@
 		FROM 
 			ypr821.plan_certificate_detail
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_certificate_code='plan_certificate_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_certificate_code=#{planCode};
 	</select>
 	
 	<!--공인어학 상세 계획  -->
@@ -103,7 +104,7 @@
 		FROM 
 			ypr821.plan_certified_language_detail
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_certified_language_code='plan_certified_language_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_certified_language_code=#{planCode};
 	</select>
 	
 	<!--기술스택 상세 계획  -->
@@ -125,7 +126,7 @@
 		FROM 
 			ypr821.plan_technology_stack_detail 
 		WHERE
-			total_plan_code='total_plan_code_01' AND plan_technology_stack_code='plan_technology_stack_code_01';
+			total_plan_code=#{totalPlanCode} AND plan_technology_stack_code=#{planCode};
 	</select>
 			 
 	<!--직종전문교육과정 상세 계획  -->
@@ -147,7 +148,7 @@
 		FROM 
 			ypr821.plan_job_training_detail 
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_job_training_code='plan_job_training_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_job_training_code=#{planCode};
 	</select>
 			 
 	<!--인턴십 상세 계획  -->
@@ -170,7 +171,7 @@
 		FROM 
 			ypr821.plan_internship_detail
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_internship_code='plan_internship_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_internship_code='plan_internship_code_01';
 	</select>
 			 
 	<!--공모전 상세 계획  -->
@@ -192,7 +193,7 @@
 		FROM 
 			ypr821.plan_contest_detail 
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_contest_code='plan_contest_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_contest_code=#{planCode};
 	</select>
 			 
 	<!--경력 상세 계획  -->
@@ -214,7 +215,7 @@
 		FROM 
 			ypr821.plan_career_detail
 		WHERE
-			 total_plan_code='total_plan_code_01' AND plan_career_code='plan_career_code_01';
+			 total_plan_code=#{totalPlanCode} AND plan_career_code=#{planCode};
 	</select>
 	<!--한명 회원의 상세 계획 조회 끝  -->
 	
@@ -223,7 +224,8 @@
 	
 	
 	<!--각 상세 계획의 통합계획 선택 AJAX  -->
-	<select id="getEduTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+	<!--학력  -->
+	<select id="getEducationalHistoryTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
 		SELECT
 				  plan_educational_history_code			AS planCode							
 				  ,plan_educational_title				AS planTitle
@@ -232,8 +234,8 @@
 		WHERE
 				total_plan_code=#{stotalPlanCode};	
 	</select>
-	
-	<select id="getProjTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+	<!--프로젝트  -->
+	<select id="getProjectTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
 		SELECT
 				  plan_project_code			AS planCode							
 				  ,plan_project_title		AS planTitle
@@ -243,12 +245,82 @@
 				total_plan_code=#{stotalPlanCode};	
 	</select>
 	
+	<!--자격증  -->
+	<select id="getCertificateTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_certificate_code			AS planCode							
+				  ,plan_certificate_title		AS planTitle
+		FROM
+				ypr821.plan_certificate
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
+	<!--공인어학  -->
+	<select id="getCertifiedLanguageTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_certified_language_code			AS planCode							
+				  ,plan_certified_language_title		AS planTitle
+		FROM
+				ypr821.plan_certified_language
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
+	
+	<!--기술스택  -->
+	<select id="getTechnologyStackTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_technology_stack_code			AS planCode							
+				  ,plan_technology_stack_title			AS planTitle
+		FROM
+				ypr821.plan_technology_stack
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
 	
 	
+	<!--직종전문교육과정  -->
+	<select id="getJobTrainingTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_job_training_code			AS planCode							
+				  ,plan_job_training_title			AS planTitle
+		FROM
+				ypr821.plan_job_training
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
+	<!--인턴십  -->
 	
+	<select id="getInternshipTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_internship_code			AS planCode							
+				  ,plan_internship_title		AS planTitle
+		FROM
+				ypr821.plan_internship
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
+	<!--공모전  -->
 	
+	<select id="getContestTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_contest_code			AS planCode							
+				  ,plan_contest_title		AS planTitle
+		FROM
+				ypr821.plan_contest
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
+	<!--경력  -->
 	
-	
+	<select id="getCareerTotalTitleSearch" parameterType="String" resultType="com.devcdper.plan.domain.PlanDto">
+		SELECT
+				  plan_career_code			AS planCode							
+				  ,plan_career_title		AS planTitle
+		FROM
+				ypr821.plan_career
+		WHERE
+				total_plan_code=#{stotalPlanCode};	
+	</select>
 	
 	
 	

--- a/TESTdevcdper/src/main/resources/static/AdminLTE3/dist/js/plan/commonDetailPlanAjax.js
+++ b/TESTdevcdper/src/main/resources/static/AdminLTE3/dist/js/plan/commonDetailPlanAjax.js
@@ -1,5 +1,8 @@
 /*AJAX*/
 
+var planName=$('.planName').val();
+console.log($('.planName').val());
+
 
 $('#totalPlan').on('change',function(){
 		var firstSelect = $("#totalPlan option:eq(0)").prop("selected"); //첫번째 option 선택
@@ -24,8 +27,8 @@ $('#totalPlan').on('change',function(){
 			var request=$.ajax({
 				url: "/totalPlanSelected",
 				method: "POST",
-				data: {stotalPlanCode:stotalPlanCode},
-				dataType: "json",   //리턴타입, 무조건 json으로 넘기려고하니 에러나지... 리턴타입을 잘 보라구~
+				data: {stotalPlanCode:stotalPlanCode, planName:planName},
+				dataType: "json",   
 				
 				
 				
@@ -33,26 +36,31 @@ $('#totalPlan').on('change',function(){
 					$('#plan').children().remove();
 					console.log("응답받은 data = ",data);
 					var htmlOption ='';
-					if(data != null && data != undefined && data !='' && data.length > 0){
-						htmlOption+="<option selected>계획을 선택해 주세요.</option>";
-						$.each(data,function(index,item){
-							htmlOption+='<option value="';
-							htmlOption+=item.planCode;
-							htmlOption+='">';
-							htmlOption+= item.planTitle;
+					
+					$.each(data,function(index,planItem){
+						console.log("ppppp",planItem);
+						if(data[planName] != null && data[planName] != undefined && data[planName] !='' && data[planName].length > 0){
+							console.log("접근성공");
+							htmlOption+="<option selected>계획을 선택해 주세요.</option>";
+							$.each(planItem,function(index,item){
+								htmlOption+='<option value="';
+								htmlOption+=item.planCode;
+								htmlOption+='">';
+								htmlOption+= item.planTitle;
+								htmlOption+='</option>';
+								
+							});
+						}else{
+							console.log('접근실패');
+							htmlOption+='<option>';
+							htmlOption+= "계획이 없습니다. 계획을 만들어주세요.";
 							htmlOption+='</option>';
-							//$('#plan').html(htmlOption);
-						});
-					}	else{
-						htmlOption+='<option>';
-						htmlOption+= "계획이 없습니다. 계획을 만들어주세요.";
-						htmlOption+='</option>';
-						//$('#plan').html(htmlOption);
-					}
-					
-					$('#plan').html(htmlOption);
-					
-					
+							
+						}
+						
+						$('#plan').html(htmlOption);
+						
+					});//바깥each문
 				},
 				error : function(xhr,status,error) {
 					console.log("xhr: " + xhr);
@@ -88,124 +96,163 @@ $("#searchBtn").on('click',function(){
 	var request=$.ajax({
 		url: "/totalAndPlanSelected",
 		method: "POST",
-		data: {totalPlanCode:totalPlanCode, planCode:planCode},
+		data: {totalPlanCode:totalPlanCode, planCode:planCode, planName:planName},
 		dataType: "json",   
 		
 		success : function(data) {
 			//$('#card-tbody').children().remove();
 			console.log("응답받은 data = ",data);
+			//상세 계획이 없을 경우 상세 계획을 등록해달라는 alert
+			if(data[planName] <= 0 ){
+				console.log(data[planName].length);
+				alert("상세 계획을 등록해 주세요.");
+			}
 			var htmltrtd ='';
 			
-			if(data != null && data != undefined && data !='' && data.length > 0){
-				$.each(data,function(index,item){
-					var color='';
-					if(item.planDetailStatus=='진행예정'){
-						color +='<span class="badge bg-warning">';
-						console.log(color);
-					}else if(item.planDetailStatus=='진행중'){
-						color +='<span class="badge bg-primary">';
-						console.log(color);
-					}else if(item.planDetailStatus=='완료'){
-						color +='<span class="badge bg-success">';
-						console.log(color);
-					}else{
-						color +='<span class="badge bg-danger">';
-						console.log(color);
+			$.each(data,function(index,planItem){
+					if(data[planName] != null && data[planName] != undefined && data[planName] !='' && data[planName].length > 0){
+						//console.log(data[planName],"data");
+						$.each(planItem,function(index,item){
+							//console.log(planItem);
+							
+							
+							var color='';
+							if(item.planDetailStatus=='진행예정'){
+								color +='<span class="badge bg-warning">';
+								console.log(color);
+							}else if(item.planDetailStatus=='진행중'){
+								color +='<span class="badge bg-primary">';
+								console.log(color);
+							}else if(item.planDetailStatus=='완료'){
+								color +='<span class="badge bg-success">';
+								console.log(color);
+							}else{
+								color +='<span class="badge bg-danger">';
+								console.log(color);
+							}
+							
+							var planCertificateDetailTypeTd=''
+							var planCertificateDetailTestDateTd=''
+							var tdClose='</td>';
+							if(item.planCertificateDetailType != null){
+								planCertificateDetailTypeTd+='<td id="planCertificateDetailType">';
+								var planCertificateDetailType=item.planCertificateDetailType;
+								console.log(planCertificateDetailType);
+								console.log(planCertificateDetailTypeTd);
+							}else{
+								$('#planCertificateDetailType').attr('style',"display:none;");
+							}
+							if(item.planCertificateDetailTestDate != null){
+								planCertificateDetailTestDateTd+='<td id="planCertificateDetailTestDate" >';
+								var planCertificateDetailTestDate=item.planCertificateDetailTestDate;
+								console.log(planCertificateDetailTestDate);
+							}else{
+								$('#planCertificateDetailTestDate').attr('style',"display:none;");
+							}	
+							
+							
+							htmltrtd+='<tr>';
+							
+							htmltrtd+='<td>';
+							htmltrtd+=index+1;
+							htmltrtd+='</td>';
+								
+							htmltrtd+='<td>';
+							htmltrtd+= item.planDetailTitle;
+							htmltrtd+='</td>';
+							
+							htmltrtd+='<td>';
+							htmltrtd+='<button type="button" class="btn btn-default btn-sm planContents" value="';
+							htmltrtd+=item.planDetailContents;
+							htmltrtd+='">상세 계획 내용보기</button>';		
+							htmltrtd+='</td>';
+							
+							
+							htmltrtd+=planCertificateDetailTypeTd;
+							htmltrtd+=planCertificateDetailType;
+							htmltrtd+=tdClose;
+							htmltrtd+=planCertificateDetailTestDateTd;
+							htmltrtd+=planCertificateDetailTestDate;
+							htmltrtd+=tdClose;
+							
+	
+							htmltrtd+='<td>';
+							htmltrtd+=item.planDetailStartDate;
+							htmltrtd+='</td>';	
+								
+							htmltrtd+='<td>';
+							htmltrtd+=item.planDetailEndDate;
+							htmltrtd+='</td>';		
+							
+							htmltrtd+='<td>';
+							htmltrtd+='<div class="progress progress-sm">';
+							htmltrtd+='<div class="progress-bar progress-bar bg-primary"';
+							htmltrtd+='role="progressbar" aria-valuenow="50" aria-valuemin="0"';
+							htmltrtd+='aria-valuemax="100" style="width: 50%"></div>';
+							htmltrtd+='</div> <small> 50% Complete </small>';
+							htmltrtd+='</td>';	
+							
+							htmltrtd+='<td>';
+							htmltrtd+=color;
+							htmltrtd+=item.planDetailStatus;
+							htmltrtd+='</span>';
+							htmltrtd+='</td>';	
+								
+							htmltrtd+='<td>';
+							htmltrtd+=item.planDetailDegree;
+							htmltrtd+='</td>';	
+								
+							htmltrtd+='<td>';
+							htmltrtd+='<button type="button" class="btn btn-default btn-sm planDegree" value="';
+							htmltrtd+= item.planDetailDegreeChangeReason;
+							htmltrtd+='">';
+							htmltrtd+='<i class="far fa-comment-alt"> 자세히 보기</i>';	
+							htmltrtd+='</button>';
+							htmltrtd+='</td>';				
+								
+							htmltrtd+='<td>';
+							htmltrtd+=item.planDetailCreatedDate;
+							htmltrtd+='</td>';	
+							
+							
+							
+							htmltrtd+='<td>';
+							htmltrtd+='<a href="/mainCoaching">'
+							htmltrtd+='<button type="button" class="btn btn-default btn-xs" id="callHelp">';	
+							htmltrtd+='<i class="fas fa-pencil-alt"> </i> 도움받기';	
+							htmltrtd+='</button>';
+							htmltrtd+='</a>';
+							
+							htmltrtd+='<a href="#">'
+							htmltrtd+='<button type="button" class="btn btn-default btn-xs" id="modifyPlan">';	
+							htmltrtd+='<i class="fas fa-pencil-alt"> </i> 수정';	
+							htmltrtd+='</button>';
+							htmltrtd+='</a>';
+							
+		
+							htmltrtd+='<a href="#>'
+							htmltrtd+='<button type="button" class="btn btn-default btn-xs" id="deletePlan">';	
+							htmltrtd+='<i class="fas fa-pencil-alt"> </i> 삭제';	
+							htmltrtd+='</button>';
+							htmltrtd+='</a>';	
+							htmltrtd+='</td>';	
+								
+							htmltrtd+='</tr>';
+						});
 					}
 					
-					htmltrtd+='<tr>';
 					
-					htmltrtd+='<td>';
-					htmltrtd+=index+1;
-					htmltrtd+='</td>';
-						
-					htmltrtd+='<td>';
-					htmltrtd+= item.planDetailTitle;
-					htmltrtd+='</td>';
+					$('#card-tbody').html(htmltrtd);
 					
-					htmltrtd+='<td>';
-					htmltrtd+='<button type="button" class="btn btn-default btn-sm planContents" value="';
-					htmltrtd+=item.planDetailContents;
-					htmltrtd+='">학력 상세 계획 내용보기</button>';		
-					htmltrtd+='</td>';
-						
-					htmltrtd+='<td>';
-					htmltrtd+=item.planDetailStartDate;
-					htmltrtd+='</td>';	
-						
-					htmltrtd+='<td>';
-					htmltrtd+=item.planDetailEndDate;
-					htmltrtd+='</td>';		
-					
-					htmltrtd+='<td>';
-					htmltrtd+='<div class="progress progress-sm">';
-					htmltrtd+='<div class="progress-bar progress-bar bg-primary"';
-					htmltrtd+='role="progressbar" aria-valuenow="50" aria-valuemin="0"';
-					htmltrtd+='aria-valuemax="100" style="width: 50%"></div>';
-					htmltrtd+='</div> <small> 50% Complete </small>';
-					htmltrtd+='</td>';	
-					
-					htmltrtd+='<td>';
-					htmltrtd+=color;
-					htmltrtd+=item.planDetailStatus;
-					htmltrtd+='</span>';
-					htmltrtd+='</td>';	
-						
-					htmltrtd+='<td>';
-					htmltrtd+=item.planDetailDegree;
-					htmltrtd+='</td>';	
-						
-					htmltrtd+='<td>';
-					htmltrtd+='<button type="button" class="btn btn-default btn-sm planDegree" value="';
-					htmltrtd+= item.planDetailDegreeChangeReason;
-					htmltrtd+='">';
-					htmltrtd+='<i class="far fa-comment-alt"> 자세히 보기</i>';	
-					htmltrtd+='</button>';
-					htmltrtd+='</td>';				
-						
-					htmltrtd+='<td>';
-					htmltrtd+=item.planDetailCreatedDate;
-					htmltrtd+='</td>';	
-					
-					
-					
-					htmltrtd+='<td>';
-					htmltrtd+='<a href="/mainCoaching">'
-					htmltrtd+='<button type="button" class="btn btn-default btn-xs" id="callHelp">';	
-					htmltrtd+='<i class="fas fa-pencil-alt"> </i> 도움받기';	
-					htmltrtd+='</button>';
-					htmltrtd+='</a>';
-					
-					htmltrtd+='<a href="#">'
-					htmltrtd+='<button type="button" class="btn btn-default btn-xs" id="modifyPlan">';	
-					htmltrtd+='<i class="fas fa-pencil-alt"> </i> 수정';	
-					htmltrtd+='</button>';
-					htmltrtd+='</a>';
-					
-
-					htmltrtd+='<a href="#>'
-					htmltrtd+='<button type="button" class="btn btn-default btn-xs" id="deletePlan">';	
-					htmltrtd+='<i class="fas fa-pencil-alt"> </i> 삭제';	
-					htmltrtd+='</button>';
-					htmltrtd+='</a>';	
-					htmltrtd+='</td>';	
-						
-					htmltrtd+='</tr>';
-				});
-			}
+					$("table").find("td").css({
+						'vertical-align' : 'middle'
+						,'text-align' : 'center'
+						});
+					$("table").find("small").css({
+						'color' : '#969696'
+					});
 			
-			
-			$('#card-tbody').html(htmltrtd);
-			
-			$("table").find("td").css({
-				'vertical-align' : 'middle'
-				,'text-align' : 'center'
-				});
-			$("table").find("small").css({
-				'color' : '#969696'
-			});
-			
-			
+				});//바깥each문
 			},
 			error : function(xhr,status,error) {
 				console.log("xhr: " + xhr);

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planCareerDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planCareerDetail.html
@@ -28,7 +28,7 @@
 				</div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planCareerDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planCareerDetail')}">
@@ -64,64 +64,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <tr th:if="${#lists.size(detailCareerPlanList) > 0}" th:each="l ,idx : ${detailCareerPlanList}">
-                      <td th:text="${idx.count}"></td>
-					  <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      <!-- Button trigger modal -->
-                        <button type="button" class="btn btn-default btn-sm planContents">
-						  경력 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2020년 3월 14일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-		              <!-- <td>2020년 7월 16일</td> -->
-                      <td>
-					   <div class="progress progress-sm" >
-					     <div class="progress-bar progress-bar bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-					   </div>
-					   <small>
-							100% Complete
-					   </small>
-					  </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-success">완료</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2020년 2월 7일</td> -->
-                      <td class="project-actions text-center">
-                      <a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a>
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="completeModifyPlanCareerDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}"  >
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>
-						</a>
-					</td>
-                    </tr>
+                  <tbody id="card-tbody">
+                    
                     
                     
                    

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planCertificateDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planCertificateDetail.html
@@ -28,7 +28,7 @@
                 </div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planCertificateDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planCertificateDetail')}">
@@ -66,65 +66,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                  	<tr th:if="${#lists.size(detailCertificatePlanList) > 0}" th:each="l ,idx : ${detailCertificatePlanList}">
-                      <td th:text="${idx.count}"></td>
-                      <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      	<!-- Button trigger modal -->
-						 <button type="button" class="btn btn-default btn-sm planContents">
-						  자격증 상세 계획 내용보기
-						</button>
-                      </td>
-                      <td th:text="${l.planCertificateDetailType}"></td>
-                      <td th:text="${l.planCertificateDetailTestDate}"></td>
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2021년 6월 30일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-                      <!-- <td>2021년 7월 15일</td> -->
-                      <td>
-                        <div class="progress progress-sm progress-striped active">
-                          <div class="progress-bar bg-warning" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
-                        </div>
-                        <small>
-							0% Complete
-						</small>
-                      </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-warning">진행예정</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 3월 22일</td> -->
-                      <td class="project-actions text-center">
-						<a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a> 
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="standbyModifyPlanCertificateDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>	
-						</a>
-					</td>
-                   </tr>
+                  <tbody id="card-tbody">
+                  	
  
  
 

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planCertifiedLanguageDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planCertifiedLanguageDetail.html
@@ -28,7 +28,7 @@
 				</div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planCertifiedLanguageDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planCertifiedLanguageDetail')}">
@@ -64,66 +64,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <tr th:if="${#lists.size(detailCertifiedLanguagePlanList) > 0}" th:each="l ,idx : ${detailCertifiedLanguagePlanList}">
-                      <td th:text="${idx.count}"></td>
-					  <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      <!-- Button trigger modal -->
-						<button type="button" class="btn btn-default btn-sm planContents"> 
-						  공인어학 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2021년 3월 5일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-		              <!-- <td>2021년 5월 22일</td> -->
-                      <td>
-					   <div class="progress progress-sm" >
-					     <div class="progress-bar progress-bar bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-					   </div>
-					   <small>
-							100% Complete
-					   </small>
-					  </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-success">완료</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td >1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 1월 1일</td> -->
-                      
-                      
-                      <td class="project-actions text-center">
-                        <a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a>
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="completeModifyPlanCertifiedLanguageDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}"  >
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>
-						</a>
-					</td>
-                    </tr>
+                  <tbody id="card-tbody">
+                    
                     
                     
                    

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planContestDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planContestDetail.html
@@ -28,7 +28,7 @@
 				</div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planContestDetail">
 						
 						<a th:href="@{/addTotalPlan(planName='planContestDetail')}">
 							<button type="button" class="btn btn-outline-primary">
@@ -63,67 +63,11 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
+                  <tbody id="card-tbody">
                     
                     
                     
-                    <tr th:if="${#lists.size(detailContestPlanList) > 0}" th:each="l ,idx : ${detailContestPlanList}">
-                      <td th:text="${idx.count}"></td>
-					  <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      	<!-- Button trigger modal -->
-						<button type="button" class="btn btn-default btn-sm planContents">
-						  공모전 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2021월 5월 5일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-                      <!-- <td>2021월 5월 30일</td> -->
-                      <td>
-                        <div class="progress progress-sm progress-striped active">
-                          <div class="progress-bar bg-primary" role="progressbar" aria-valuenow="50" aria-valuemin="0" aria-valuemax="100" style="width: 50%"></div>
-                        </div>
-                        <small>
-							50% Complete
-						</small>
-                      </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-primary">진행중</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 4월 23일</td> -->
-                      <td class="project-actions text-center">
-                      <a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a>
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="progressingModifyPlanContestDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>	
-						</a>
-					</td>
-                    </tr>
+                    
                     
                     
  

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planEducationalHistoryDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planEducationalHistoryDetail.html
@@ -32,7 +32,7 @@
                 </div>
 					
 					<div class="card-tools">
-					
+						<input type="hidden" class="planName" name="planName" value="planEducationalHistoryDetail"><!-- th:value="${planName}" -->
 
 						<!-- <a th:href="@{/addPlanEducationalHistoryDetail(planDetailName='학력 상세 계획')}"> -->
 						<a th:href="@{/addTotalPlan(planName='planEducationalHistoryDetail')}">  <!-- 인터셉터 인경우 사용:${pathName}  -->   <!--(planDetailName='학력 상세 계획')  -->
@@ -50,7 +50,10 @@
               </div>
               <!-- /.card-header -->
               <div class="card-body  table-responsive p-0" style="overflow: scroll; white-space: nowrap;">
-              	
+              	 
+              	 <!-- <input type="hidden" name="realPathName" th:value="${realPathName}"> -->
+              	 
+              	 
                 <table class="table table-striped text-nowrap">
                   <thead>
                     <tr>
@@ -66,6 +69,7 @@
                       <th style="text-align: center;">작성일자</th>
                       
                       <th> </th>
+                     
                     </tr>
                   </thead>
 					<tbody id="card-tbody">
@@ -100,34 +104,15 @@
 
 <th:bolck layout:fragment="pageJavascript">
 	<script type="text/javascript">
-		/* $(document).ready(function(){
-			$('#modal-planEducationalHistoryDetail').on('shown.bs.modal',function(){
-				
-			});
-		}); */
-		
-		
-		//$(function(){
-			/* parameter 영역 */
-			//var planContents = $(".planContents");
-			//var planDegree = $(".planDegree");
-			
-			
-			/* ${detailPlanList.get(0).getPlanDetailContents()} */ //참고용
-			/* <![CDATA[ */
-			/* ]]> */
 			
 			
 			
-			///get(여기를 어떻게  풀지?)
-			/* for(var i=0;detailPlanList.size();i++){
-				detailPlanList.get(i).getPlanDetailContents();
-			} *///여기서 detailPlanList를 어떻게 정의 해야되는거지...
 			
 			
 			/* Modal 영역 */  //동적으로 하려면  (click뒤에다쓰고) DOM객체에 다시한번 언급해줘야되는 것임.
 			$(document).on('click',".planContents",function(){
 				$("#myModal").modal();
+				//$(".modal-title").text();
 				$(".modal-text").text($(this).val());
 			//console.log(planText);
 			});
@@ -159,12 +144,10 @@
 				'color' : '#969696'
 			});
 			
-			
-			/* //selected 출력			
-			$("#plan").change(function(){
-				var value = $("#plan option:checked").text(); //$(this).val();
-				$("#planSelected").text(value);
-			}); */ 
+			/*location.pathname을 이용해서 컨트롤러에 값을 주고 받아올 수 있나?*/
+			/* var locationPathName= location.pathname;
+			var realPathName=locationPathName.substring(1);
+			console.log(locationPathName+" , "+realPathName); */
 			
 			
 			

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planInternshipDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planInternshipDetail.html
@@ -28,7 +28,7 @@
 				</div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planInternshipDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planInternshipDetail')}">
@@ -64,64 +64,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <tr th:if="${#lists.size(detailInternshipPlanList) > 0}" th:each="l ,idx : ${detailInternshipPlanList}">
-                      <td th:text="${idx.count}"></td>
-					  <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      <!-- Button trigger modal -->
-						<button type="button" class="btn btn-default btn-sm planContents">
-						  공인어학 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2020년 10월 15일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-		              <!-- <td>2020년 10월 24일</td> -->
-                      <td>
-					   <div class="progress progress-sm" >
-					     <div class="progress-bar progress-bar bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-					   </div>
-					   <small>
-							100% Complete
-					   </small>
-					  </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-success">완료</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 4월 23일</td> -->
-                      <td class="project-actions text-center">
-                      <a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a>
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="completeModifyPlanInternshipDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}"  >
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>
-						</a>
-					</td>
-                    </tr>
+                  <tbody id="card-tbody">
+                    
                     
                     
                     

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planJobTrainingDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planJobTrainingDetail.html
@@ -28,7 +28,7 @@
 				</div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planJobTrainingDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planJobTrainingDetail')}">
@@ -64,64 +64,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <tr th:if="${#lists.size(detailJobTrainingPlanList) > 0}" th:each="l ,idx : ${detailJobTrainingPlanList}">
-                      <td th:text="${idx.count}"></td>
-					  <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      <!-- Button trigger modal -->
-                        <button type="button" class="btn btn-default btn-sm planContents">
-						  직종전문교육과정 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2021년 4월 15일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-		              <!-- <td>2021년 4월 30일</td> -->
-                      <td>
-					   <div class="progress progress-sm" >
-					     <div class="progress-bar progress-bar bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-					   </div>
-					   <small>
-							100% Complete
-					   </small>
-					  </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-success">완료</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 4월 13일</td> -->
-                      <td class="project-actions text-center">
-                      <a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a>
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="completeModifyPlanJobTrainingDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}"  >
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>
-						</a>
-					</td>
-                    </tr>
+                  <tbody id="card-tbody">
+                    
                     
                     
                    

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planProjectDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planProjectDetail.html
@@ -30,7 +30,7 @@
                 </div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planProjectDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planProjectDetail')}">
@@ -66,67 +66,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <tr th:if="${#lists.size(detailProjectjPlanList) > 0}" th:each="l ,idx : ${detailProjectjPlanList}">
-						<td th:text="${idx.count}"></td>
-						<td th:text="${l.planDetailTitle}"></td>
-                     
-                      
-                      <td>
-                      <!-- Button trigger modal -->
-						<button type="button" class="btn btn-default btn-sm planContents">
-						  프로젝트 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2021년 4월 22일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-		              <!-- <td>2021년 5월 5일</td> -->
-                      <td>
-					   <div class="progress progress-sm" >
-					     <div class="progress-bar progress-bar bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-					   </div>
-					   <small>
-							100% Complete
-					   </small>
-					  </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-success">완료</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!--  <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 4월 20일</td> -->
-                      
-                      <td class="project-actions text-center">
-                       <a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a> 
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="completeModifyPlanProjectDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}"  >
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>
-						</a>
-					</td>
-                   </tr>
+                  <tbody id="card-tbody">
+                    
                     
 
              </tbody>
@@ -161,6 +102,7 @@
 			/* Modal 영역 */
 			$(document).on('click',".planContents",function(){
 				$("#myModal").modal();
+				console.log($(this).val());
 				$(".modal-text").text($(this).val());
 			});
 			$(document).on('click',".planDegree",function(){

--- a/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planTechnologyStackDetail.html
+++ b/TESTdevcdper/src/main/resources/templates/plan/detailPlan/planTechnologyStackDetail.html
@@ -28,7 +28,7 @@
 				</div>
 					
 					<div class="card-tools">
-					
+					<input type="hidden" class="planName" name="planName" value="planTechnologyStackDetail">
 						
 
 						<a th:href="@{/addTotalPlan(planName='planTechnologyStackDetail')}">
@@ -64,64 +64,8 @@
                       <th> </th>
                     </tr>
                   </thead>
-                  <tbody>
-                    <tr th:if="${#lists.size(detailTechnologyStackPlanList) > 0}" th:each="l ,idx : ${detailTechnologyStackPlanList}">
-                      <td th:text="${idx.count}"></td>
-					  <td th:text="${l.planDetailTitle}"></td>
-                      <td>
-                      <!-- Button trigger modal -->
-						<button type="button" class="btn btn-default btn-sm planContents">
-						  기술스택 상세 계획 내용보기
-						</button>
-                      </td>
-                      
-                      <td th:text="${l.planDetailStartDate}"></td>
-                      <!-- <td>2021년 5월 1일</td> -->
-                      <td th:text="${l.planDetailEndDate}"></td>
-		              <!-- <td>2021년 5월 25일</td> -->
-                      <td>
-					   <div class="progress progress-sm" >
-					     <div class="progress-bar progress-bar bg-success" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%"></div>
-					   </div>
-					   <small>
-							100% Complete
-					   </small>
-					  </td>
-                      <td th:text="${l.planDetailStatus}"><span class="badge bg-success">완료</span></td>
-                      <td th:text="${l.planDetailDegree} + '차'"></td>
-                      <!-- <td>1차</td> -->
-                      <td>
-						<!-- 차수변경사유 모달   --> 
-						<button type="button" class="btn btn-default btn-sm planDegree">
-							<i class="far fa-comment-alt"> 자세히 보기</i>
-						</button>
-					  </td>
-                      <!-- <td>모달</td> -->
-                      <td th:text="${l.planDetailCreatedDate}"></td>
-                      <!-- <td>2021년 4월 20일</td> -->
-                      <td class="project-actions text-center">
-                      	<a th:href="@{/mainCoaching}">
-										<button type="button" class="btn btn-default btn-xs"
-											id="callHelp">
-											<i class="fas fa-pencil-alt"> </i> 도움받기
-										</button>
-						</a>
-						<a th:href="@{#}">
-							<button type="button" class="btn btn-default btn-xs" id="completeModifyPlanTechnologyStackDetail" >
-								<i class="fas fa-pencil-alt">
-								</i>
-								수정
-							</button>
-						</a>
-						<a  th:href="@{#}"  >
-							<button type="button" class="btn btn-default btn-xs" >
-								<i class="fas fa-trash">
-								</i>
-								삭제
-							</button>
-						</a>
-					</td>
-                    </tr>
+                  <tbody id="card-tbody">
+                    
                     
                     
                     


### PR DESCRIPTION
author: 류준혁

file:
[templates/plan/detailPlan]
planCareerDetail.html
planCertificateDetail.html
planCertifiedLanguageDetail.html
planContestDetail.html
planEducationalHistoryDetail.html
planInternshipDetail.html
planJobTrainingDetail.html
planProjectDetail.html
planTechnologyStackDetail.html

[com.devcdper.plan.controller]
-DetailPlanController.java

[com.devcdper.plan.service]
-DetailPlanService.java

[com.devcdper.plan.dao]
-DetailPlanMapper.java

[resources/mapper]
-DetailPlanMapper.xml

[resources/static/AdminLTE3/dist/js/plan]
-commonDetailPlanAjax.js


detail:
[templates/plan/detailPlan]
planCareerDetail.html
planCertificateDetail.html
planCertifiedLanguageDetail.html
planContestDetail.html
planEducationalHistoryDetail.html
planInternshipDetail.html
planJobTrainingDetail.html
planProjectDetail.html
planTechnologyStackDetail.html
-컨트롤러에 key값을 가져올 input:hidden 안에 각각의 vlaue값을 지정함.
-ajax로 tbody에 innerhtml을 받아오기 위해 id 설정

[com.devcdper.plan.controller]
DetailPlanController.java
-각 view와 연결되는 메서드들에 임의의 email값을 넣어 totalPlanCode를 가져올 수 있게 함.
-주석으로 표시한 AJAX1(통합계획 선택시 계획값 셋팅), AJAX2(검색버튼 눌렀을시 리스트 가져오기)에
 각 해당 페이지마다 다른 계획명과 그에 해당하는 상세 계획 리스트를 가져올 수 있게 함.

[com.devcdper.plan.service]
DetailPlanService.java
-각 상세계획마다 통합계획 및 계획 선택, 통합계획 및 계획에 해당하는 상세계획을 가져오는 메서드 추가

[com.devcdper.plan.dao]
DetailPlanMapper.java
-각 상세계획마다 통합계획 및 계획 선택, 통합계획 및 계획에 해당하는 상세계획을 가져오는 메서드 추가

[mapper]
DetailPlanMapper.xml
-각 상세계획마다 통합계획 및 계획 선택, 통합계획 및 계획에 해당하는 상세계획을 가져오는 SQL쿼리 추가

[resources/static/AdminLTE3/dist/js/plan]
commonDetailPlanAjax.js
-각 상세 계획 페이지 별로 통합계획 선택시 페이지 맞는 계획값을 가져올 수 있게 함.
-검색 버튼 눌렀을 시 각 상세 계획 페이지에 맞게 리스트를 출력하고, 상세계획이 없을 경우 등록해주세요 alert추가.


-등록, 수정 작업 진행중